### PR TITLE
[API] - Auth api 함수 작성

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,3 +1,8 @@
+import { useMutation, useQuery } from 'react-query';
+import { authInfoState } from '@/atoms';
+import { User } from '@/types';
+import { AxiosError } from 'axios';
+import { useSetRecoilState } from 'recoil';
 import useAxiosInstance from './instance';
 
 interface SignUpRequestBody {
@@ -5,17 +10,87 @@ interface SignUpRequestBody {
 	fullName: string;
 	password: string;
 }
+
 export const useFetchSignUp = async (body: SignUpRequestBody) => {
 	const { baseInstance } = useAxiosInstance();
-	try {
-		const { data, status } = await baseInstance.post('/signup', body);
-		if (status === 200) {
-			return data;
-		} else {
-			throw new Error('정상적인 status가 아닙니다.');
-		}
-	} catch (error) {
-		console.error(error);
-		return false;
-	}
+	const { isSuccess, isError, isLoading } = useMutation(() =>
+		baseInstance.post('/signup', body),
+	);
+	return {
+		isSuccess,
+		isError,
+		isLoading,
+	};
+};
+
+interface LoginRequestBody {
+	email: string;
+	password: string;
+}
+
+interface LoginResponse {
+	user: User;
+	token: string;
+}
+
+export const useFetchLogin = async (body: LoginRequestBody) => {
+	const { baseInstance } = useAxiosInstance();
+	const setAuth = useSetRecoilState(authInfoState);
+	const { data, isSuccess, isError, isLoading } = useMutation<
+		LoginResponse,
+		AxiosError,
+		LoginResponse
+	>('login', () => baseInstance.post('/login', body), {
+		onSuccess: (data) => {
+			setAuth({
+				userId: data.user._id,
+				token: data.token,
+			});
+		},
+	});
+
+	return {
+		data: data?.user._id,
+		isSuccess,
+		isError,
+		isLoading,
+	};
+};
+
+// 로그아웃
+export const useFetchLogOut = async () => {
+	const { authInstance } = useAxiosInstance();
+	const { isSuccess, isError, isLoading } = useMutation('logOut', () =>
+		authInstance.post('/logout'),
+	);
+
+	return {
+		isSuccess,
+		isError,
+		isLoading,
+	};
+};
+
+// 로그인 인증
+export const useFetchAuthUser = async () => {
+	const { authInstance } = useAxiosInstance();
+	const { data, isSuccess, isError, isLoading } = useQuery<
+		User,
+		AxiosError,
+		string | null
+	>('authUser', () => authInstance.get('/auth-user'), {
+		select: (data) => {
+			if (data) {
+				return data._id;
+			}
+			return null;
+		},
+	});
+
+	return {
+		data,
+		isSuccess,
+		isError,
+		isLoading,
+	};
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,21 @@
+import useAxiosInstance from './instance';
+
+interface SignUpRequestBody {
+	email: string;
+	fullName: string;
+	password: string;
+}
+export const useFetchSignUp = async (body: SignUpRequestBody) => {
+	const { baseInstance } = useAxiosInstance();
+	try {
+		const { data, status } = await baseInstance.post('/signup', body);
+		if (status === 200) {
+			return data;
+		} else {
+			throw new Error('정상적인 status가 아닙니다.');
+		}
+	} catch (error) {
+		console.error(error);
+		return false;
+	}
+};

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,9 +1,9 @@
-import { authTokenState } from '@/atoms';
+import { authInfoState } from '@/atoms';
 import axios from 'axios';
 import { useRecoilValue } from 'recoil';
 
 const useAxiosInstance = () => {
-	const token = useRecoilValue(authTokenState);
+	const auth = useRecoilValue(authInfoState);
 	const baseInstance = axios.create({
 		baseURL: 'https://kdt.frontend.4th.programmers.co.kr:5001/',
 	});
@@ -11,7 +11,7 @@ const useAxiosInstance = () => {
 	const authInstance = axios.create({
 		baseURL: 'https://kdt.frontend.4th.programmers.co.kr:5001/',
 		headers: {
-			Authorization: token,
+			Authorization: auth?.token,
 		},
 	});
 

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,20 +1,18 @@
-import { tokenStorage } from '@/storage';
+import { AuthInfo, authInfoStorage } from '@/storage';
 import { atom, selector } from 'recoil';
 
-const authToken = atom<string | null>({
-	key: 'authToken',
-	default: tokenStorage.getItem(),
+const authInfo = atom<AuthInfo | null>({
+	key: 'authInfo',
+	default: authInfoStorage.getItem(),
 });
 
-export const authTokenState = selector({
-	key: 'autoTokenState',
+export const authInfoState = selector({
+	key: 'autoInfoState',
 	get: ({ get }) => {
-		return get(authToken);
+		return get(authInfo);
 	},
-	set: ({ set }, newToken) => {
-		set(authToken, newToken);
-		if (typeof newToken === 'string') {
-			tokenStorage.setItem(newToken);
-		}
+	set: ({ set }, newInfo) => {
+		set(authInfo, newInfo);
+		authInfoStorage.setItem(newInfo as AuthInfo);
 	},
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,4 +1,5 @@
-import { AuthInfo, authInfoStorage } from '@/storage';
+import { authInfoStorage } from '@/storage';
+import { AuthInfo } from '@/types/auth';
 import { atom, selector } from 'recoil';
 
 const authInfo = atom<AuthInfo | null>({

--- a/src/components/FetchTest/index.tsx
+++ b/src/components/FetchTest/index.tsx
@@ -1,0 +1,58 @@
+import { useFetchLogOut, useFetchLogin, useFetchSignUp } from '@/apis/auth';
+
+const FetchTest = () => {
+	const { signUp, isSignUpError, isSignUpLoading, isSignUpSuccess } =
+		useFetchSignUp();
+	const { login, loginData, isLoginError, isLoginLoading, isLoginSuccess } =
+		useFetchLogin();
+	const { logOut, isLogOutError, isLogOutLoading, isLogOutSuccess } =
+		useFetchLogOut();
+	return (
+		<>
+			<div>
+				<button
+					onClick={() =>
+						signUp({
+							email: 'hello',
+							password: '1234',
+							fullName: 'testName',
+						})
+					}>
+					signup
+				</button>
+				<button
+					onClick={() =>
+						login({
+							email: 'hello',
+							password: '1234',
+						})
+					}>
+					login
+				</button>
+				<button onClick={() => logOut()}>logout</button>
+			</div>
+			<div>
+				<h1>signup</h1>
+				<div>loading : {isSignUpLoading ? 'loading' : 'not loading'}</div>
+				<div>success : {isSignUpSuccess ? 'success' : 'fail'}</div>
+				<div>error : {isSignUpError ? 'error' : 'none'}</div>
+			</div>
+			<div>
+				<h1>login</h1>
+				<div>userId : {loginData.userId}</div>
+				<div>userName: {loginData.fullName}</div>
+				<div>loading : {isLoginLoading ? 'loading' : 'not loading'}</div>
+				<div>success : {isLoginSuccess ? 'success' : 'fail'}</div>
+				<div>error : {isLoginError ? 'error' : 'none'}</div>
+			</div>
+			<div>
+				<h1>logOut</h1>
+				<div>loading : {isLogOutLoading ? 'loading' : 'not loading'}</div>
+				<div>success : {isLogOutSuccess ? 'success' : 'fail'}</div>
+				<div>error : {isLogOutError ? 'error' : 'none'}</div>
+			</div>
+		</>
+	);
+};
+
+export default FetchTest;

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,9 +1,5 @@
+import { AuthInfo } from '@/types/auth';
 import _Storage from './storage';
-
-export interface AuthInfo {
-	token: string;
-	userId: string;
-}
 
 export const authInfoStorage = new _Storage<AuthInfo | null>({
 	storage: localStorage,

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,7 +1,12 @@
 import _Storage from './storage';
 
-export const tokenStorage = new _Storage<string | null>({
+export interface AuthInfo {
+	token: string;
+	userId: string;
+}
+
+export const authInfoStorage = new _Storage<AuthInfo | null>({
 	storage: localStorage,
-	key: 'auth-token',
+	key: 'auth-info',
 	defaultValue: null,
 });

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,4 @@
+export interface AuthInfo {
+	token: string;
+	userId: string;
+}


### PR DESCRIPTION
## 📑 구현 사항 

- [x] auth api 함수
  - [x] signUp
  - [x] login
  - [x] logOut
  - [x] authUser
- [x] storage + recoil 저장 정보 수정
- [x] FetchTest 컴포넌트 추가 (참고용)

<br/>

## 🚧 특이 사항

### storage, recoil 에 저장되는 authInfo
```tsx
export interface AuthInfo {
  token: string;  //user.token
  userId: string; //user._id (식별자)
}
```
### ✅ useFetch 함수 규칙 (useMutation 사용 시 = post, put, delete)
> #### data 를 따로 반환하지 않을 때
```tsx
const useFetch이름 = () => {
        const { baseInstance } = useAxiosInstance();
	const { mutate, isLoading, isError, isSuccess } = useMutation(
		'이름',
		(body: RequestBodyType) => baseInstance.post('/url', body), // api 명세에 있는 requestBody 인터페이스 넣기
                { } // option 이 있다면 작성
	);
	return {
		이름: mutate,
		is이름Loading: isLoading,
		is이름Error: isError,
		is이름Success: isSuccess,
	};
}
```
> #### data 반환이 있을 때
```tsx
const useFetch이름 = () => {
       const { baseInstance } = useAxiosInstance();
	const { mutate, data, isLoading, isError, isSuccess } = useMutation<
		AxiosResponse<ResponseType>, // api 명세에 있는 response 인터페이스 넣기
		AxiosError,
		RequestBodyType // api 명세에 있는 requestBody 인터페이스 넣기
	>(
		'이름',
		(body: RequestBodyType) => baseInstance.post('/url', body),
                { } // option 이 있다면 작성
	);
	return {
		이름: mutate,
                이름data: {  fullName: data?.data.user.fullName  }, // 예시, data 한번 더 넣어줘야 함
		is이름Loading: isLoading,
		is이름Error: isError,
		is이름Success: isSuccess,
	};
}
```

### ✅ FetchTest 컴포넌트 (테스트 코드, useFetch hook 활용 시 이렇게!)
여기에 코드 블럭으로 넣으려다가, 굉장히 길어서 .. 그냥 이 친구도 푸시하겠습니다!
FetchTest 컴포넌트 폴더를 참고하시면 됩니다

</br>

## 🚨관련 이슈

#12