### PR TITLE
[Component] - Header 컴포넌트 구현

### DIFF
--- a/src/components/Header/constants/index.ts
+++ b/src/components/Header/constants/index.ts
@@ -1,0 +1,9 @@
+export const TITLE: Record<string, string> = {
+	signup: '회원 가입',
+	login: '로그인',
+	user: '유저 정보',
+	post: '포스트 피드',
+	'create-post': '포스트 작성',
+	search: '에 대한 검색 결과',
+	mypage: '마이 페이지',
+};

--- a/src/components/Header/constants/index.ts
+++ b/src/components/Header/constants/index.ts
@@ -1,9 +1,10 @@
 export const TITLE: Record<string, string> = {
-	signup: '회원 가입',
-	login: '로그인',
-	user: '유저 정보',
-	post: '포스트 피드',
-	'create-post': '포스트 작성',
-	search: '에 대한 검색 결과',
-	mypage: '마이 페이지',
+	'/': '포스트 피드',
+	'/signup': '회원 가입',
+	'/login': '로그인',
+	'/user': '유저 정보',
+	'/post': '포스트 피드',
+	'/create-post': '포스트 작성',
+	'/search': '에 대한 검색 결과',
+	'/mypage': '마이 페이지',
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import styled from '@emotion/styled';
+import { getPathname, getTitle } from './utils';
+
+const Header = () => {
+	const INITIAL_KEYWORD =
+		getPathname(2) === 'post' ? '전체 포스트' : '전체 유저';
+
+	const location = useLocation();
+	const navigate = useNavigate();
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const [selectValue, setSelectValue] = useState<string>('follower');
+	const [keyword, setKeyword] = useState(INITIAL_KEYWORD);
+	const [tabValue, setTabValue] = useState('post');
+	const title = getTitle(location.pathname);
+
+	const onChangeSelect = (value: string) => {
+		searchParams.set('sort', value);
+		setSearchParams(searchParams);
+	};
+
+	const onClickTabBar = (value: string) => {
+		const checkPath = getPathname(2);
+
+		if (value === 'user') {
+			if (checkPath === 'user') {
+				return;
+			}
+
+			navigate('/search/user?sort=follower');
+		}
+
+		if (value === 'post') {
+			if (checkPath === 'post') {
+				return;
+			}
+
+			navigate('/search/post?sort=recent');
+		}
+	};
+
+	useEffect(() => {
+		const currentSort = searchParams.get('sort');
+		const currentKeyword = searchParams.get('keyword');
+
+		if (currentSort) {
+			setSelectValue(currentSort);
+		}
+
+		if (currentKeyword) {
+			setKeyword(currentKeyword);
+		}
+	}, [searchParams]);
+
+	useEffect(() => {
+		setTabValue(getPathname(2));
+
+		const currentKeyword = searchParams.get('keyword');
+
+		if (!currentKeyword) {
+			setKeyword(INITIAL_KEYWORD);
+		}
+	}, [tabValue, location.pathname, INITIAL_KEYWORD, searchParams]);
+
+	return (
+		<Container>
+			<SortSelect
+				id="orderSelect"
+				name="order"
+				value={selectValue}
+				onChange={(e) => {
+					onChangeSelect(e.target.value);
+				}}>
+				{tabValue === 'user' ? (
+					<>
+						<option value="follower">팔로워순</option>
+						<option value="like">좋아요순</option>
+					</>
+				) : (
+					<>
+						<option value="recent">최신순</option>
+						<option value="like">좋아요순</option>
+					</>
+				)}
+			</SortSelect>
+
+			<Title>
+				<Keyword>
+					{keyword && getPathname(1) === 'search' ? keyword : null}
+				</Keyword>
+				{title}
+			</Title>
+
+			<TabBar>
+				<TabBarList
+					className={tabValue === 'user' ? 'bold' : ''}
+					onClick={() => onClickTabBar('user')}>
+					유저
+				</TabBarList>
+				<TabBarList
+					className={tabValue === 'post' ? 'bold' : ''}
+					onClick={() => onClickTabBar('post')}>
+					포스트
+				</TabBarList>
+			</TabBar>
+		</Container>
+	);
+};
+
+export default Header;
+
+const Container = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 80%;
+	border: 1px solid black;
+	border-radius: 20px 20px 0 0;
+	padding: 0 10px;
+`;
+const SortSelect = styled.select`
+	border-radius: 20px;
+	cursor: pointer;
+	padding: 5px 10px;
+`;
+
+const Title = styled.div``;
+
+const Keyword = styled.span`
+	font-weight: 600;
+`;
+
+const TabBar = styled.ul`
+	display: flex;
+	list-style: none;
+`;
+
+const TabBarList = styled.li`
+	padding-left: 10px;
+	cursor: pointer;
+
+	&:first-of-type {
+		padding-right: 10px;
+		border-right: 1px solid black;
+	}
+
+	&.bold {
+		font-weight: 800;
+	}
+`;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { getPathname } from '@/utils';
 import styled from '@emotion/styled';
-import { getPathname, getTitle } from './utils';
+import { getTitle } from './utils';
 
 const Header = () => {
 	const INITIAL_KEYWORD =

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -55,7 +55,7 @@ const Header = () => {
 	}, [searchParams]);
 
 	useEffect(() => {
-		setTabValue(getPathname(2));
+		setTabValue(getPathname(2) ?? 'post');
 
 		const currentKeyword = searchParams.get('keyword');
 
@@ -66,25 +66,29 @@ const Header = () => {
 
 	return (
 		<Container>
-			<SortSelect
-				id="orderSelect"
-				name="order"
-				value={selectValue}
-				onChange={(e) => {
-					onChangeSelect(e.target.value);
-				}}>
-				{tabValue === 'user' ? (
-					<>
-						<option value="follower">팔로워순</option>
-						<option value="like">좋아요순</option>
-					</>
-				) : (
-					<>
-						<option value="recent">최신순</option>
-						<option value="like">좋아요순</option>
-					</>
-				)}
-			</SortSelect>
+			{['', 'search', 'post'].some((path) => path === getPathname(1)) ? (
+				<SortSelect
+					id="orderSelect"
+					name="order"
+					value={selectValue}
+					onChange={(e) => {
+						onChangeSelect(e.target.value);
+					}}>
+					{tabValue === 'user' ? (
+						<>
+							<option value="follower">팔로워순</option>
+							<option value="like">좋아요순</option>
+						</>
+					) : (
+						<>
+							<option value="recent">최신순</option>
+							<option value="like">좋아요순</option>
+						</>
+					)}
+				</SortSelect>
+			) : (
+				<div />
+			)}
 
 			<Title>
 				<Keyword>
@@ -93,18 +97,22 @@ const Header = () => {
 				{title}
 			</Title>
 
-			<TabBar>
-				<TabBarList
-					className={tabValue === 'user' ? 'bold' : ''}
-					onClick={() => onClickTabBar('user')}>
-					유저
-				</TabBarList>
-				<TabBarList
-					className={tabValue === 'post' ? 'bold' : ''}
-					onClick={() => onClickTabBar('post')}>
-					포스트
-				</TabBarList>
-			</TabBar>
+			{getPathname(1) === 'search' ? (
+				<TabBar>
+					<TabBarList
+						className={tabValue === 'user' ? 'bold' : ''}
+						onClick={() => onClickTabBar('user')}>
+						유저
+					</TabBarList>
+					<TabBarList
+						className={tabValue === 'post' ? 'bold' : ''}
+						onClick={() => onClickTabBar('post')}>
+						포스트
+					</TabBarList>
+				</TabBar>
+			) : (
+				<div />
+			)}
 		</Container>
 	);
 };
@@ -119,11 +127,13 @@ const Container = styled.div`
 	border: 1px solid black;
 	border-radius: 20px 20px 0 0;
 	padding: 0 10px;
+	height: 50px;
 `;
 const SortSelect = styled.select`
 	border-radius: 20px;
 	cursor: pointer;
 	padding: 5px 10px;
+	outline: none;
 `;
 
 const Title = styled.div``;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -66,7 +66,7 @@ const Header = () => {
 
 	return (
 		<Container>
-			{['', 'search', 'post'].some((path) => path === getPathname(1)) ? (
+			{['', 'post', 'search'].some((path) => path === getPathname(1)) ? (
 				<SortSelect
 					id="orderSelect"
 					name="order"

--- a/src/components/Header/utils/index.ts
+++ b/src/components/Header/utils/index.ts
@@ -1,0 +1,9 @@
+import { TITLE } from '../constants';
+
+export const getPathname = (segment: number) => {
+	return location.pathname.split('/')[segment];
+};
+
+export const getTitle = (pathname: string) => {
+	return pathname.startsWith(`/${getPathname(1)}`) && TITLE[getPathname(1)];
+};

--- a/src/components/Header/utils/index.ts
+++ b/src/components/Header/utils/index.ts
@@ -5,5 +5,7 @@ export const getPathname = (segment: number) => {
 };
 
 export const getTitle = (pathname: string) => {
-	return pathname.startsWith(`/${getPathname(1)}`) && TITLE[getPathname(1)];
+	return (
+		pathname.startsWith(`/${getPathname(1)}`) && TITLE[`/${getPathname(1)}`]
+	);
 };

--- a/src/components/Header/utils/index.ts
+++ b/src/components/Header/utils/index.ts
@@ -1,8 +1,5 @@
+import { getPathname } from '@/utils';
 import { TITLE } from '../constants';
-
-export const getPathname = (segment: number) => {
-	return location.pathname.split('/')[segment];
-};
 
 export const getTitle = (pathname: string) => {
 	return (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export const getPathname = (segment: number) => {
+	return location.pathname.split('/')[segment];
+};


### PR DESCRIPTION
## 📑 구현 사항 

- [x] Select 변경 시 router 변경 (sort), 반대로 sort 쿼리 스트링을 감지하여 Select 값도 변경됨
- [x] 현재 라우터를 기준으로 Title 변경 (회원 가입, 로그인, 유저 정보, 포스트 피드, 포스트 작성, 마이 페이지 ${query}에 대한 검색 결과)
- [x] 주소의 검색 query를 감지하여 Title에 적용
- [x] TabBar 변경 시 router 변경 (user/post), 반대로 url을 감지하여 유저, 포스트도 자동으로 선택됨
- [x] home, post, search 페이지에서만 select가 보이게 적용 
- [x] TabBar의 현재 카테고리를 중복 선택되지 않게 적용 
- [x] search 페이지에서만 TabBar가 보이게 적용
<br/>

## 🚧 특이 사항
기능 구현이 우선이라 하였기에 현재는 세부 컴포넌트들을 분리하지 않았습니다.

작성한 유틸 함수와 상수는 일단 Header에서만 사용될 것 같고, 혹시 모를 충돌에 방지하기 위해  Header 폴더 내부에 utils와 constants 폴더를 생성하였습니다. 추후 피드백 주시면 반영하도록 하겠습니다.

getPathname함수는 URL의 n번째 부분 경로를 리턴하는 함수입니다.
```ts
// 현재 URL: /search/post?sort=follower

const firstPath = getPathname(1); // search
const secondPath = getPathname(2); // post
```

<br>

title은 TITLE이라는 객체를 만들어놓고 현재 URL의 시작 부분(root 뒷부분부터)을 감지하여 해당하는 값을 지정하였습니다.

처음에는 1번째 부분 경로와 비교하여 title을 반환했지만 `/user`가 아닌 `/user/1` 일때 '유저 정보' 라는 타이틀을 리턴해야 하는 경우에는 예외가 발생해서 startsWith 함수를 사용하였습니다.
```ts
export const TITLE: Record<string, string> = {
	'/': '포스트 피드',
	'/signup': '회원 가입',
	'/login': '로그인',
	'/user': '유저 정보',
	'/post': '포스트 피드',
	'/create-post': '포스트 작성',
	'/search': '에 대한 검색 결과',
	'/mypage': '마이 페이지',
};

export const getTitle = (pathname: string) => {
	return (
		pathname.startsWith(`/${getPathname(1)}`) && TITLE[`/${getPathname(1)}`]
	);
}; // 현재 URL이 /user/1이어도 '유저 정보'가 리턴됨


```

</br>

## 🚨관련 이슈

#21 