### PR TITLE
[Page] - 검색 페이지 구현

### DIFF
--- a/src/apis/search.ts
+++ b/src/apis/search.ts
@@ -4,7 +4,7 @@ import { Post, User } from '@type/index';
 import useAxiosInstance from './instance';
 
 interface SearchRequestQuery {
-  query: string;
+  query?: string;
 }
 
 export const useFetchSearchPosts = ({ query }: SearchRequestQuery) => {

--- a/src/apis/search.ts
+++ b/src/apis/search.ts
@@ -30,7 +30,7 @@ export const useFetchSearchUsers = ({ query }: SearchRequestQuery) => {
     AxiosError
   >('searchUsers', () => baseInstance.get(`/search/users/${query}`));
   return {
-    searchUsersData: data?.data,
+    searchUsersData: data?.data.filter((user) => user.role !== 'SuperAdmin'),
     isSearchUsersSuccess: isSuccess,
     isSearchUsersError: isError,
     isSearchUsersLoading: isLoading,

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -1,0 +1,32 @@
+import PostListItem from '@components/PostListItem';
+import { useFetchAllPosts } from '@apis/post';
+import { useFetchSearchPosts } from '@apis/search';
+import { getSortPostList } from './utils';
+
+interface PostListProps {
+  keyword?: string;
+  sort: string;
+}
+
+const PostList = ({ keyword, sort }: PostListProps) => {
+  const { searchPostsData } = useFetchSearchPosts({ query: keyword });
+  const { allPostsData } = useFetchAllPosts();
+  const resultData = keyword
+    ? getSortPostList(searchPostsData, sort, keyword)
+    : getSortPostList(allPostsData, sort, keyword);
+
+  return (
+    <ul>
+      {resultData?.map((post) => (
+        <PostListItem
+          key={post._id}
+          id={post._id}
+          image={post.author.image}
+          title={post.title}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export default PostList;

--- a/src/components/PostList/utils/index.ts
+++ b/src/components/PostList/utils/index.ts
@@ -1,0 +1,14 @@
+import { Post } from '@type/index';
+
+export const getSortPostList = (
+  searchData: Post[] | undefined,
+  sort: string,
+  keyword?: string,
+): Post[] | undefined => {
+  if (sort === 'recent' && keyword) {
+    return searchData?.slice().reverse();
+  } else if (sort === 'like') {
+    return searchData?.sort((a, b) => b.likes.length - a.likes.length);
+  }
+  return searchData;
+};

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+
+interface PostListItemProps {
+  id: string;
+  image: string;
+  title: string;
+}
+
+const PostListItem = ({ id, image, title }: PostListItemProps) => {
+  return (
+    <ListItemContainer>
+      <Profile>프로필</Profile>
+      <Title>{title}</Title>
+      <More> more</More>
+    </ListItemContainer>
+  );
+};
+
+export default PostListItem;
+
+const ListItemContainer = styled.li`
+  display: flex;
+  border: 1px solid black;
+  margin: 30px 0;
+  gap: 20px;
+  border-radius: 12px;
+`;
+
+const Profile = styled.div`
+  border: 1px solid black;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+  margin-left: 10px;
+  margin: 10px 0 10px 10px;
+`;
+
+const Title = styled.div`
+  border: 1px solid black;
+  border-radius: 30px;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 14px 0;
+`;
+
+const More = styled.div`
+  border-left: 1px solid black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 60px;
+  cursor: pointer;
+`;

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -10,7 +10,7 @@ interface UserListProps {
 
 const UserList = ({ keyword, sort }: UserListProps) => {
   const { searchUsersData } = useFetchSearchUsers({ query: keyword });
-  const { data: usersData } = useFetchUsers();
+  const { usersData } = useFetchUsers();
 
   const resultData = keyword
     ? getSortUserList(searchUsersData, sort)

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -1,0 +1,35 @@
+import UserListItem from '@components/UserListItem';
+import { useFetchSearchUsers } from '@apis/search';
+import { useFetchUsers } from '@apis/user';
+import { getSortUserList } from './utils';
+
+interface UserListProps {
+  keyword?: string;
+  sort: string;
+}
+
+const UserList = ({ keyword, sort }: UserListProps) => {
+  const { searchUsersData } = useFetchSearchUsers({ query: keyword });
+  const { data: usersData } = useFetchUsers();
+
+  const resultData = keyword
+    ? getSortUserList(searchUsersData, sort)
+    : getSortUserList(usersData, sort);
+
+  return (
+    <ul>
+      {resultData?.map((user) => (
+        <UserListItem
+          key={user._id}
+          id={user._id}
+          image={user.image}
+          name={user.fullName}
+          likes={user.likes.length}
+          followers={user.followers.length}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export default UserList;

--- a/src/components/UserList/utils/index.ts
+++ b/src/components/UserList/utils/index.ts
@@ -1,0 +1,17 @@
+import { User } from '@type/index';
+
+export const getSortUserList = (
+  searchData:
+    | Pick<User, 'image' | 'likes' | '_id' | 'fullName' | 'followers'>[]
+    | undefined,
+  sort: string,
+):
+  | Pick<User, 'image' | 'likes' | '_id' | 'fullName' | 'followers'>[]
+  | undefined => {
+  if (sort === 'follower') {
+    return searchData?.sort((a, b) => b.followers.length - a.followers.length);
+  } else if (sort === 'like') {
+    return searchData?.sort((a, b) => b.likes.length - a.likes.length);
+  }
+  return searchData;
+};

--- a/src/components/UserList/utils/index.ts
+++ b/src/components/UserList/utils/index.ts
@@ -1,13 +1,9 @@
 import { User } from '@type/index';
 
 export const getSortUserList = (
-  searchData:
-    | Pick<User, 'image' | 'likes' | '_id' | 'fullName' | 'followers'>[]
-    | undefined,
+  searchData: User[] | undefined,
   sort: string,
-):
-  | Pick<User, 'image' | 'likes' | '_id' | 'fullName' | 'followers'>[]
-  | undefined => {
+): User[] | undefined => {
   if (sort === 'follower') {
     return searchData?.sort((a, b) => b.followers.length - a.followers.length);
   } else if (sort === 'like') {

--- a/src/components/UserListItem/index.tsx
+++ b/src/components/UserListItem/index.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+
+interface UserListItemProps {
+  id: string;
+  image: string;
+  name: string;
+  likes: number;
+  followers: number;
+}
+
+const UserListItem = ({
+  id,
+  image,
+  name,
+  likes,
+  followers,
+}: UserListItemProps) => {
+  return (
+    <List>
+      <Profile>프로필</Profile>
+      <UserInfo>
+        <div>{name} 🌱 🐣</div>
+        <LikesAndFollowers>
+          <div>👍{likes}</div>
+          <div>🙍{followers}</div>
+        </LikesAndFollowers>
+      </UserInfo>
+      <More> more</More>
+    </List>
+  );
+};
+
+export default UserListItem;
+
+const List = styled.li`
+  display: flex;
+  border: 1px solid black;
+  margin: 30px 0;
+  gap: 20px;
+  border-radius: 12px;
+`;
+
+const Profile = styled.div`
+  border: 1px solid black;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+  margin-left: 10px;
+  margin: 10px 0 10px 10px;
+`;
+
+const UserInfo = styled.div`
+  flex-grow: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 14px 0;
+`;
+
+const LikesAndFollowers = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const More = styled.div`
+  border-left: 1px solid black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 60px;
+  cursor: pointer;
+`;

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import PostList from '@components/PostList';
+import UserList from '@components/UserList';
+
+interface SearchProps {
+  target: string;
+  keyword?: string;
+  sort: string;
+}
+
+const SearchPage = ({ target = 'post', keyword, sort }: SearchProps) => {
+  return (
+    <Container>
+      {target === 'user' ? (
+        <UserList
+          keyword={keyword}
+          sort={sort}
+        />
+      ) : (
+        <PostList
+          keyword={keyword}
+          sort={sort}
+        />
+      )}
+    </Container>
+  );
+};
+
+export default SearchPage;
+
+const Container = styled.div`
+  width: 80%;
+  border: 1px solid black;
+  border-top: none;
+  padding: 20px 10px;
+`;


### PR DESCRIPTION
## 📑 구현 사항 
- [x] 사용자 검색 컴포넌트 추가
- [x] 포스트 검색 컴포넌트 추가
- [x] 검색 API 연동 및 화면 렌더링
- [x] 반복되는 ListItem 컴포넌트 구현
- [x] sort 값에 따른 List 정렬 적용

<br/>

## 🚧 특이 사항
전체 유저, 포스트 목록은 내림차순, 검색한 유저, 포스트 목록은 오름차순으로 정렬되기 때문에 정렬 함수에 keyword를 전달하여 구분하였습니다.
```ts
export const getSortPostList = (
  searchData: Post[] | undefined,
  sort: string,
  keyword?: string,
): Post[] | undefined => {
  if (sort === 'recent' && keyword) {
    return searchData?.slice().reverse();
  } else if (sort === 'like') {
    return searchData?.sort((a, b) => b.likes.length - a.likes.length);
  }
  return searchData;
};
```

</br>

## 🚨관련 이슈

#33 