### PR TITLE
[Page] - CreatePost 페이지 구현

### DIFF
--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -64,19 +64,16 @@ export const useFetchCreatePost = () => {
   const path = `/posts/create`;
 
   const { mutate, data, isLoading, isSuccess, isError } = useMutation<
-  AxiosResponse<Post>,
-  AxiosError,
-  CreatePostRequestBody>
-  (
-    'createPostMutation',
-    (body: CreatePostRequestBody) => {
-      const formData = new FormData();
-      formData.append('title', body.title);
-      formData.append('image', '');
-      formData.append('channelId', CHANNEL_ID);
-      return authInstance.post(path, formData);
-    },
-  );
+    AxiosResponse<Post>,
+    AxiosError,
+    CreatePostRequestBody
+  >('createPostMutation', (body: CreatePostRequestBody) => {
+    const formData = new FormData();
+    formData.append('title', body.title);
+    formData.append('image', '');
+    formData.append('channelId', CHANNEL_ID);
+    return authInstance.post(path, formData);
+  });
   return {
     createPostMutate: mutate,
     createPostData: data?.data._id,

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -63,7 +63,11 @@ export const useFetchCreatePost = () => {
   const { authInstance } = useAxiosInstance();
   const path = `/posts/create`;
 
-  const { mutate, isLoading, isSuccess, isError } = useMutation(
+  const { mutate, data, isLoading, isSuccess, isError } = useMutation<
+  AxiosResponse<Post>,
+  AxiosError,
+  CreatePostRequestBody>
+  (
     'createPostMutation',
     (body: CreatePostRequestBody) => {
       const formData = new FormData();
@@ -75,6 +79,7 @@ export const useFetchCreatePost = () => {
   );
   return {
     createPostMutate: mutate,
+    createPostData: data?.data._id,
     isCreatePostLoading: isLoading,
     isCreatePostSuccess: isSuccess,
     isCreatePostError: isError,

--- a/src/pages/CreatePostPage/CreatePostSuccessModal/index.tsx
+++ b/src/pages/CreatePostPage/CreatePostSuccessModal/index.tsx
@@ -4,18 +4,15 @@ import styled from '@emotion/styled';
 import LinkButton from '@components/NavBar/LinkButton';
 
 interface CreatePostSuccessModalProps {
-  postId: string;
+  postId: string | null;
 }
 
 const CreatePostSuccessModal = ({ postId }: CreatePostSuccessModalProps) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const handleKeyDown = (e: Event) => {
-      if (
-        e instanceof KeyboardEvent &&
-        (e.key === 'Enter' || e.key === 'Escape')
-      ) {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === 'Escape') {
         navigate(`/post/${postId}`);
       }
     };

--- a/src/pages/CreatePostPage/CreatePostSuccessModal/index.tsx
+++ b/src/pages/CreatePostPage/CreatePostSuccessModal/index.tsx
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import styled from '@emotion/styled';
+import LinkButton from '@components/NavBar/LinkButton';
+
+interface CreatePostSuccessModalProps {
+  postId: string;
+}
+
+const CreatePostSuccessModal = ({ postId }: CreatePostSuccessModalProps) => {
+  useEffect(() => {
+    const handleKeyDown = (e: Event) => {
+      if (
+        e instanceof KeyboardEvent &&
+        (e.key === 'Enter' || e.key === 'Escape')
+      ) {
+        // TODO: /post/posdId로 이동시켜주기
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  });
+
+  return (
+    <ModalContainer>
+      <ModalContent>
+        <ModalText>포스트 작성에 성공했습니다 !</ModalText>
+        <LinkButton to={`/post/${postId}`}>확인</LinkButton>
+      </ModalContent>
+    </ModalContainer>
+  );
+};
+
+export default CreatePostSuccessModal;
+
+const ModalContainer = styled.div`
+  background-color: rgba(0, 0, 0, 0.4);
+  width: 100%;
+  height: 100vh;
+  z-index: 10;
+  position: fixed;
+  top: 0;
+  left: 0;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 32px;
+  width: 360px;
+  height: 200px;
+  z-index: 100;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 10px;
+  background-color: white;
+  box-shadow: 6px 6px 6px rgba(0, 0, 0, 0.25);
+`;
+
+const ModalText = styled.p`
+  font-size: 20px;
+  margin-bottom: 32px;
+`;
+
+// TODO: 링크 버튼 스타일 넣어주기

--- a/src/pages/CreatePostPage/CreatePostSuccessModal/index.tsx
+++ b/src/pages/CreatePostPage/CreatePostSuccessModal/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import LinkButton from '@components/NavBar/LinkButton';
 
@@ -7,13 +8,15 @@ interface CreatePostSuccessModalProps {
 }
 
 const CreatePostSuccessModal = ({ postId }: CreatePostSuccessModalProps) => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     const handleKeyDown = (e: Event) => {
       if (
         e instanceof KeyboardEvent &&
         (e.key === 'Enter' || e.key === 'Escape')
       ) {
-        // TODO: /post/posdId로 이동시켜주기
+        navigate(`/post/${postId}`);
       }
     };
 
@@ -22,7 +25,7 @@ const CreatePostSuccessModal = ({ postId }: CreatePostSuccessModalProps) => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  });
+  }, []);
 
   return (
     <ModalContainer>
@@ -69,5 +72,3 @@ const ModalText = styled.p`
   font-size: 20px;
   margin-bottom: 32px;
 `;
-
-// TODO: 링크 버튼 스타일 넣어주기

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, KeyboardEvent, useState } from 'react';
+import { ChangeEvent, FocusEvent, useState } from 'react';
 import styled from '@emotion/styled';
 import Spinner from '@components/Spinner';
 import { useFetchCreatePost } from '@apis/post';
@@ -20,7 +20,14 @@ const CreatePostPage = () => {
     isCreatePostError,
   } = useFetchCreatePost();
 
-  const handleChangeInputValues = (e: ChangeEvent<HTMLInputElement>) => {
+  const isCreatePostPossible: boolean =
+    inputValues.title.length > 0 &&
+    inputValues.optionA.length > 0 &&
+    inputValues.optionB.length > 0;
+
+  const handleChangeInputValues = (
+    e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>,
+  ) => {
     const { id, value } = e.target;
     setInputValues({
       ...inputValues,
@@ -28,20 +35,7 @@ const CreatePostPage = () => {
     });
   };
 
-  const isCreatePostPossible: boolean =
-    inputValues.title.length > 0 &&
-    inputValues.optionA.length > 0 &&
-    inputValues.optionB.length > 0;
-
-  const handlePreventEnterKeySubmit = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-    }
-  };
-
-  const handleSubmitCreatePost = (e: FormEvent) => {
-    e.preventDefault();
-
+  const handleClickCreatePost = () => {
     if (!isCreatePostPossible) return;
 
     const postTitle = joinDataBySeparator(
@@ -53,53 +47,66 @@ const CreatePostPage = () => {
     createPostMutate({ title: postTitle });
   };
 
+  const handleBlurTrim = (
+    e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { id, value } = e.target;
+    setInputValues({
+      ...inputValues,
+      [id]: value.trim(),
+    });
+  };
+
   return (
     <>
       {isCreatePostLoading ? (
         <Spinner size={100} />
       ) : (
-        <StyledForm onSubmit={handleSubmitCreatePost}>
+        <PageContainer>
           <TitleContainer>
             <TitleInput
               id="title"
               placeholder="한 줄 설명 쓰기"
               value={inputValues.title}
-              maxLength={99}
+              maxLength={100}
               onChange={handleChangeInputValues}
-              onKeyDown={handlePreventEnterKeySubmit}
+              onBlur={handleBlurTrim}
             />
-            <TitleLengthLimit>{inputValues.title.length} / 100</TitleLengthLimit>
+            <TitleLengthLimit>
+              {inputValues.title.length} / 100
+            </TitleLengthLimit>
           </TitleContainer>
-          <ContentContainer>
-            <OptionContainer>
-              <OptionLabel>A 항목</OptionLabel>
+
+          <OptionContainer>
+            <OptionContent>
+              <OptionName>A 항목</OptionName>
               <OptionInput
                 id="optionA"
                 value={inputValues.optionA}
-                maxLength={99}
+                maxLength={100}
                 onChange={handleChangeInputValues}
-                onKeyDown={handlePreventEnterKeySubmit}
+                onBlur={handleBlurTrim}
               />
-            </OptionContainer>
+            </OptionContent>
 
             <p>VS</p>
 
-            <OptionContainer>
-              <OptionLabel>B 항목</OptionLabel>
+            <OptionContent>
+              <OptionName>B 항목</OptionName>
               <OptionInput
                 id="optionB"
                 value={inputValues.optionB}
-                maxLength={99}
+                maxLength={100}
                 onChange={handleChangeInputValues}
-                onKeyDown={handlePreventEnterKeySubmit}
+                onBlur={handleBlurTrim}
               />
-            </OptionContainer>
-          </ContentContainer>
+            </OptionContent>
+          </OptionContainer>
 
-          <ButtonWrapper>
+          <ButtonContainer>
             <StyledButton
-              type="submit"
-              disabled={!isCreatePostPossible}>
+              disabled={!isCreatePostPossible}
+              onClick={handleClickCreatePost}>
               작성 완료하기
             </StyledButton>
             {isCreatePostError && (
@@ -107,13 +114,13 @@ const CreatePostPage = () => {
                 포스트 작성에 실패했습니다 !
               </CreatePostFailText>
             )}
-          </ButtonWrapper>
-        </StyledForm>
+          </ButtonContainer>
+        </PageContainer>
       )}
 
       {isCreatePostSuccess && (
         <CreatePostSuccessModal
-          postId={createPostData === undefined ? 'anyPostId' : createPostData}
+          postId={createPostData === undefined ? null : createPostData}
         />
       )}
     </>
@@ -122,7 +129,7 @@ const CreatePostPage = () => {
 
 export default CreatePostPage;
 
-const StyledForm = styled.form`
+const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -144,7 +151,7 @@ const TitleContainer = styled.div`
 const TitleInput = styled.input`
   border: none;
   outline: none;
-  width: 85%;
+  width: 80%;
   padding: 6px 12px;
 `;
 
@@ -152,7 +159,7 @@ const TitleLengthLimit = styled.span`
   box-sizing: border-box;
 `;
 
-const ContentContainer = styled.div`
+const OptionContainer = styled.div`
   margin-top: 32px;
   display: flex;
   justify-content: space-between;
@@ -160,29 +167,29 @@ const ContentContainer = styled.div`
   width: 80%;
 `;
 
-const OptionContainer = styled.div`
+const OptionContent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
 `;
 
-const OptionLabel = styled.label`
+const OptionName = styled.p`
   box-sizing: border-box;
 `;
 
-const OptionInput = styled.input`
+const OptionInput = styled.textarea`
   box-sizing: border-box;
   padding: 20px;
+  margin-top: 12px;
   border: 2px solid black;
   border-radius: 16px;
   outline: none;
   width: 300px;
   height: 200px;
-
-  white-space: pre-line;
+  font-size: 24px;
 `;
 
-const ButtonWrapper = styled.div`
+const ButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled';
+
+const CreatePostPage = () => {
+  return (
+    <StyledForm>
+      <TitleInput placeholder="한 줄 설명 쓰기" />
+
+      <ContentContainer>
+        <OptionContainer>
+          <label>A 항목</label>
+          <OptionInput />
+        </OptionContainer>
+
+        <p>VS</p>
+
+        <OptionContainer>
+          <label>B 항목</label>
+          <OptionInput />
+        </OptionContainer>
+      </ContentContainer>
+
+      <StyledButton>작성 완료하기</StyledButton>
+    </StyledForm>
+  );
+};
+
+export default CreatePostPage;
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  width: 80%;
+`;
+
+const TitleInput = styled.input`
+  margin-top: 32px;
+  border: 2px solid black;
+  border-radius: 16px;
+  outline: none;
+  width: 100%;
+  padding: 6px 12px;
+`;
+
+const ContentContainer = styled.div`
+  margin-top: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const OptionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const OptionInput = styled.div`
+  border: 2px solid black;
+  border-radius: 16px;
+  outline: none;
+  width: 300px;
+  height: 200px;
+`;
+
+const StyledButton = styled.button`
+  margin-top: 32px;
+  border: 2px solid black;
+  border-radius: 16px;
+`;

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -14,6 +14,7 @@ const CreatePostPage = () => {
 
   const {
     createPostMutate,
+    createPostData,
     isCreatePostLoading,
     isCreatePostSuccess,
     isCreatePostError,
@@ -58,22 +59,24 @@ const CreatePostPage = () => {
         <Spinner size={100} />
       ) : (
         <StyledForm onSubmit={handleSubmitCreatePost}>
-          <TitleInput
-            id="title"
-            placeholder="한 줄 설명 쓰기"
-            value={inputValues.title}
-            maxLength={100}
-            onChange={handleChangeInputValues}
-            onKeyDown={handlePreventEnterKeySubmit}
-          />
-
+          <TitleContainer>
+            <TitleInput
+              id="title"
+              placeholder="한 줄 설명 쓰기"
+              value={inputValues.title}
+              maxLength={99}
+              onChange={handleChangeInputValues}
+              onKeyDown={handlePreventEnterKeySubmit}
+            />
+            <TitleLengthLimit>{inputValues.title.length} / 100</TitleLengthLimit>
+          </TitleContainer>
           <ContentContainer>
             <OptionContainer>
               <OptionLabel>A 항목</OptionLabel>
               <OptionInput
                 id="optionA"
                 value={inputValues.optionA}
-                maxLength={100}
+                maxLength={99}
                 onChange={handleChangeInputValues}
                 onKeyDown={handlePreventEnterKeySubmit}
               />
@@ -86,7 +89,7 @@ const CreatePostPage = () => {
               <OptionInput
                 id="optionB"
                 value={inputValues.optionB}
-                maxLength={100}
+                maxLength={99}
                 onChange={handleChangeInputValues}
                 onKeyDown={handlePreventEnterKeySubmit}
               />
@@ -109,7 +112,9 @@ const CreatePostPage = () => {
       )}
 
       {isCreatePostSuccess && (
-        <CreatePostSuccessModal postId="65005b6d583dc7337ffaf578" />
+        <CreatePostSuccessModal
+          postId={createPostData === undefined ? 'anyPostId' : createPostData}
+        />
       )}
     </>
   );
@@ -125,13 +130,26 @@ const StyledForm = styled.form`
   width: 60%;
 `;
 
-const TitleInput = styled.input`
+const TitleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 8px;
   margin-top: 32px;
   border: 2px solid black;
   border-radius: 16px;
-  outline: none;
   width: 80%;
+`;
+const TitleInput = styled.input`
+  border: none;
+  outline: none;
+  width: 85%;
   padding: 6px 12px;
+`;
+
+const TitleLengthLimit = styled.span`
+  box-sizing: border-box;
 `;
 
 const ContentContainer = styled.div`
@@ -160,6 +178,8 @@ const OptionInput = styled.input`
   outline: none;
   width: 300px;
   height: 200px;
+
+  white-space: pre-line;
 `;
 
 const ButtonWrapper = styled.div`

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -1,25 +1,79 @@
+import { ChangeEvent, FormEvent, KeyboardEvent, useState } from 'react';
 import styled from '@emotion/styled';
 
 const CreatePostPage = () => {
+  const [inputValues, setInputValues] = useState({
+    title: '',
+    optionA: '',
+    optionB: '',
+  });
+
+  const handleChangeInputValues = (e: ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    setInputValues({
+      ...inputValues,
+      [id]: value,
+    });
+  };
+
+  const isMakePostPossible: boolean =
+    inputValues.title.length > 0 &&
+    inputValues.optionA.length > 0 &&
+    inputValues.optionB.length > 0;
+
+  const handleEnterKeySubmit = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  };
+
+  const handleSubmitMakePost = (e: FormEvent) => {
+    e.preventDefault();
+    console.log('전송합니다');
+  };
+
   return (
-    <StyledForm>
-      <TitleInput placeholder="한 줄 설명 쓰기" />
+    <StyledForm onSubmit={handleSubmitMakePost}>
+      <TitleInput
+        id="title"
+        placeholder="한 줄 설명 쓰기"
+        value={inputValues.title}
+        maxLength={100}
+        onChange={handleChangeInputValues}
+        onKeyDown={handleEnterKeySubmit}
+      />
 
       <ContentContainer>
         <OptionContainer>
           <label>A 항목</label>
-          <OptionInput />
+          <OptionInput
+            id="optionA"
+            value={inputValues.optionA}
+            maxLength={100}
+            onChange={handleChangeInputValues}
+            onKeyDown={handleEnterKeySubmit}
+          />
         </OptionContainer>
 
         <p>VS</p>
 
         <OptionContainer>
           <label>B 항목</label>
-          <OptionInput />
+          <OptionInput
+            id="optionB"
+            value={inputValues.optionB}
+            maxLength={100}
+            onChange={handleChangeInputValues}
+            onKeyDown={handleEnterKeySubmit}
+          />
         </OptionContainer>
       </ContentContainer>
 
-      <StyledButton>작성 완료하기</StyledButton>
+      <StyledButton
+        type="submit"
+        disabled={!isMakePostPossible}>
+        작성 완료하기
+      </StyledButton>
     </StyledForm>
   );
 };
@@ -31,7 +85,7 @@ const StyledForm = styled.form`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  width: 80%;
+  width: 60%;
 `;
 
 const TitleInput = styled.input`
@@ -39,7 +93,7 @@ const TitleInput = styled.input`
   border: 2px solid black;
   border-radius: 16px;
   outline: none;
-  width: 100%;
+  width: 80%;
   padding: 6px 12px;
 `;
 
@@ -48,7 +102,7 @@ const ContentContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 100%;
+  width: 80%;
 `;
 
 const OptionContainer = styled.div`
@@ -56,7 +110,9 @@ const OptionContainer = styled.div`
   flex-direction: column;
   align-items: center;
 `;
-const OptionInput = styled.div`
+const OptionInput = styled.input`
+  box-sizing: border-box;
+  padding: 20px;
   border: 2px solid black;
   border-radius: 16px;
   outline: none;
@@ -68,4 +124,6 @@ const StyledButton = styled.button`
   margin-top: 32px;
   border: 2px solid black;
   border-radius: 16px;
+  width: 20%;
+  height: 40px;
 `;

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Spinner from '@components/Spinner';
 import { useFetchCreatePost } from '@apis/post';
 import { joinDataBySeparator } from '@utils/parseDataBySeparator';
+import CreatePostSuccessModal from './CreatePostSuccessModal';
 
 const CreatePostPage = () => {
   const [inputValues, setInputValues] = useState({
@@ -11,8 +12,12 @@ const CreatePostPage = () => {
     optionB: '',
   });
 
-  const { createPostMutate, isCreatePostLoading, isCreatePostSuccess } =
-    useFetchCreatePost();
+  const {
+    createPostMutate,
+    isCreatePostLoading,
+    isCreatePostSuccess,
+    isCreatePostError,
+  } = useFetchCreatePost();
 
   const handleChangeInputValues = (e: ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
@@ -22,7 +27,7 @@ const CreatePostPage = () => {
     });
   };
 
-  const isMakePostPossible: boolean =
+  const isCreatePostPossible: boolean =
     inputValues.title.length > 0 &&
     inputValues.optionA.length > 0 &&
     inputValues.optionB.length > 0;
@@ -33,11 +38,10 @@ const CreatePostPage = () => {
     }
   };
 
-  const handleSubmitMakePost = (e: FormEvent) => {
+  const handleSubmitCreatePost = (e: FormEvent) => {
     e.preventDefault();
 
-    // 3개 input 창 모두 입력되어있을 때만 API 호출 가능
-    if (!isMakePostPossible) return;
+    if (!isCreatePostPossible) return;
 
     const postTitle = joinDataBySeparator(
       inputValues.title,
@@ -45,20 +49,15 @@ const CreatePostPage = () => {
       inputValues.optionB,
     );
 
-    console.log(`postTitle을 ${postTitle}로 api에 넣어줄 것임`);
-
-    createPostMutate({ title: postTitle }); // 이후 isLoading, isSuccess 바뀔 것임
+    createPostMutate({ title: postTitle });
   };
 
   return (
     <>
       {isCreatePostLoading ? (
-        <Spinner
-          size={100}
-          color={'#111111'}
-        />
+        <Spinner size={100} />
       ) : (
-        <StyledForm onSubmit={handleSubmitMakePost}>
+        <StyledForm onSubmit={handleSubmitCreatePost}>
           <TitleInput
             id="title"
             placeholder="한 줄 설명 쓰기"
@@ -70,7 +69,7 @@ const CreatePostPage = () => {
 
           <ContentContainer>
             <OptionContainer>
-              <label>A 항목</label>
+              <OptionLabel>A 항목</OptionLabel>
               <OptionInput
                 id="optionA"
                 value={inputValues.optionA}
@@ -83,7 +82,7 @@ const CreatePostPage = () => {
             <p>VS</p>
 
             <OptionContainer>
-              <label>B 항목</label>
+              <OptionLabel>B 항목</OptionLabel>
               <OptionInput
                 id="optionB"
                 value={inputValues.optionB}
@@ -94,12 +93,23 @@ const CreatePostPage = () => {
             </OptionContainer>
           </ContentContainer>
 
-          <StyledButton
-            type="submit"
-            disabled={!isMakePostPossible}>
-            작성 완료하기
-          </StyledButton>
+          <ButtonWrapper>
+            <StyledButton
+              type="submit"
+              disabled={!isCreatePostPossible}>
+              작성 완료하기
+            </StyledButton>
+            {isCreatePostError && (
+              <CreatePostFailText>
+                포스트 작성에 실패했습니다 !
+              </CreatePostFailText>
+            )}
+          </ButtonWrapper>
         </StyledForm>
+      )}
+
+      {isCreatePostSuccess && (
+        <CreatePostSuccessModal postId="65005b6d583dc7337ffaf578" />
       )}
     </>
   );
@@ -137,6 +147,11 @@ const OptionContainer = styled.div`
   flex-direction: column;
   align-items: center;
 `;
+
+const OptionLabel = styled.label`
+  box-sizing: border-box;
+`;
+
 const OptionInput = styled.input`
   box-sizing: border-box;
   padding: 20px;
@@ -147,10 +162,20 @@ const OptionInput = styled.input`
   height: 200px;
 `;
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 const StyledButton = styled.button`
   margin-top: 32px;
   border: 2px solid black;
   border-radius: 16px;
-  width: 20%;
+  width: 200px;
   height: 40px;
+`;
+
+const CreatePostFailText = styled.span`
+  margin-top: 12px;
+  color: red;
 `;

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -1,5 +1,8 @@
 import { ChangeEvent, FormEvent, KeyboardEvent, useState } from 'react';
 import styled from '@emotion/styled';
+import Spinner from '@components/Spinner';
+import { useFetchCreatePost } from '@apis/post';
+import { joinDataBySeparator } from '@utils/parseDataBySeparator';
 
 const CreatePostPage = () => {
   const [inputValues, setInputValues] = useState({
@@ -7,6 +10,9 @@ const CreatePostPage = () => {
     optionA: '',
     optionB: '',
   });
+
+  const { createPostMutate, isCreatePostLoading, isCreatePostSuccess } =
+    useFetchCreatePost();
 
   const handleChangeInputValues = (e: ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
@@ -21,7 +27,7 @@ const CreatePostPage = () => {
     inputValues.optionA.length > 0 &&
     inputValues.optionB.length > 0;
 
-  const handleEnterKeySubmit = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handlePreventEnterKeySubmit = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
     }
@@ -29,52 +35,73 @@ const CreatePostPage = () => {
 
   const handleSubmitMakePost = (e: FormEvent) => {
     e.preventDefault();
-    console.log('전송합니다');
+
+    // 3개 input 창 모두 입력되어있을 때만 API 호출 가능
+    if (!isMakePostPossible) return;
+
+    const postTitle = joinDataBySeparator(
+      inputValues.title,
+      inputValues.optionA,
+      inputValues.optionB,
+    );
+
+    console.log(`postTitle을 ${postTitle}로 api에 넣어줄 것임`);
+
+    createPostMutate({ title: postTitle }); // 이후 isLoading, isSuccess 바뀔 것임
   };
 
   return (
-    <StyledForm onSubmit={handleSubmitMakePost}>
-      <TitleInput
-        id="title"
-        placeholder="한 줄 설명 쓰기"
-        value={inputValues.title}
-        maxLength={100}
-        onChange={handleChangeInputValues}
-        onKeyDown={handleEnterKeySubmit}
-      />
-
-      <ContentContainer>
-        <OptionContainer>
-          <label>A 항목</label>
-          <OptionInput
-            id="optionA"
-            value={inputValues.optionA}
+    <>
+      {isCreatePostLoading ? (
+        <Spinner
+          size={100}
+          color={'#111111'}
+        />
+      ) : (
+        <StyledForm onSubmit={handleSubmitMakePost}>
+          <TitleInput
+            id="title"
+            placeholder="한 줄 설명 쓰기"
+            value={inputValues.title}
             maxLength={100}
             onChange={handleChangeInputValues}
-            onKeyDown={handleEnterKeySubmit}
+            onKeyDown={handlePreventEnterKeySubmit}
           />
-        </OptionContainer>
 
-        <p>VS</p>
+          <ContentContainer>
+            <OptionContainer>
+              <label>A 항목</label>
+              <OptionInput
+                id="optionA"
+                value={inputValues.optionA}
+                maxLength={100}
+                onChange={handleChangeInputValues}
+                onKeyDown={handlePreventEnterKeySubmit}
+              />
+            </OptionContainer>
 
-        <OptionContainer>
-          <label>B 항목</label>
-          <OptionInput
-            id="optionB"
-            value={inputValues.optionB}
-            maxLength={100}
-            onChange={handleChangeInputValues}
-            onKeyDown={handleEnterKeySubmit}
-          />
-        </OptionContainer>
-      </ContentContainer>
+            <p>VS</p>
 
-      <StyledButton
-        type="submit"
-        disabled={!isMakePostPossible}>
-        작성 완료하기
-      </StyledButton>
-    </StyledForm>
+            <OptionContainer>
+              <label>B 항목</label>
+              <OptionInput
+                id="optionB"
+                value={inputValues.optionB}
+                maxLength={100}
+                onChange={handleChangeInputValues}
+                onKeyDown={handlePreventEnterKeySubmit}
+              />
+            </OptionContainer>
+          </ContentContainer>
+
+          <StyledButton
+            type="submit"
+            disabled={!isMakePostPossible}>
+            작성 완료하기
+          </StyledButton>
+        </StyledForm>
+      )}
+    </>
   );
 };
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,10 +1,5 @@
 export { default as SearchPage } from '@pages/SearchPage';
 export { default as LoginPage } from '@pages/LoginPage';
 export { default as SignUpPage } from '@pages/SignUpPage';
-export {
-  CreatePostPage,
-  HomePage,
-  UserPage,
-  MyPage,
-  PostPage,
-} from '@pages/tempPages';
+export { default as CreatePostPage } from '@pages/CreatePostPage';
+export { HomePage, UserPage, MyPage, PostPage } from '@pages/tempPages';


### PR DESCRIPTION
### 구현 영상
https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/31370590/42f42201-9082-49cf-b21d-ad0944abcacb
### UI 및 데이터 흐름 
![createPost-flow](https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/31370590/06c8ccaa-cacc-4679-992e-626db1a151c7)

## 📑 구현 사항 
- [x] 포스트 작성 페이지 기본 UI 구현
- [x] 유저에게 포스트 `title`, `A항목`, `B항목` 입력받고 이를 컴포넌트 내 state로 관리
- [x] 작성 완료 버튼 클릭 시 `useFetchCreatePost` API 호출
- [x] 작성 완료 시, 포스트 작성 성공 모달로 이동 => Enter키,  Esc키 누르거나 확인 버튼 클릭 => 해당 포스트 하나씩 보기 페이지 이동 
- [x] 작성 실패 시, 페이지 이동 X => 작성에 실패했습니다 문구 띄워줌

<br/>

## 🚧 특이 사항
9/14까지 리뷰 부탁드립니다 ! 사실 다른 분들과 겹치는 부분이 많이 없는 독립적인 페이지라서 발생될 만한 문제는 없을 것 같지만 개선하거나 수정할 사항 있는지 한번씩 확인해주시면 감사하겠습니다 !

</br>

## 🚨관련 이슈
#43 