### PR TITLE
[Fix] - 정렬 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -53,13 +53,13 @@ const Header = ({ title, sortProps, keyword }: HeaderProps) => {
           }}>
           {target === 'user' ? (
             <>
-              <option value="follower">팔로워순</option>
-              <option value="like">좋아요순</option>
+              <option value="follower">팔로워 순</option>
+              <option value="level">레벨 순</option>
             </>
           ) : (
             <>
-              <option value="recent">최신순</option>
-              <option value="like">좋아요순</option>
+              <option value="recent">최신 순</option>
+              <option value="like">좋아요 순</option>
             </>
           )}
         </SortSelect>
@@ -122,7 +122,7 @@ const Title = styled.div`
   font-size: 36px;
   font-style: normal;
   font-weight: 700;
-  line-height: 150%; 
+  line-height: 150%;
 `;
 
 const Keyword = styled.span`

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -19,9 +19,7 @@ const Main = () => {
     <MainContainer>
       <Header
         title={title}
-        sortProps={
-          name === 'home' || name === 'search' ? objectForSort : undefined
-        }
+        sortProps={name === 'search' ? objectForSort : undefined}
         keyword={
           name === 'search'
             ? search.keyword ||
@@ -72,7 +70,7 @@ const MainContainer = styled.div`
 
 const PageContainer = styled.div`
   box-sizing: border-box;
-  display: flex; 
+  display: flex;
   align-self: stretch;
   justify-content: center;
   padding: 50px 50px 0px 50px;

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import PostListItem from '@components/PostListItem';
+import Spinner from '@components/Spinner';
 import { useFetchAllPosts } from '@apis/post';
 import { useFetchSearchPosts } from '@apis/search';
 import { getSortPostList } from './utils';
@@ -10,10 +11,12 @@ interface PostListProps {
 }
 
 const PostList = ({ keyword, sort }: PostListProps) => {
-  const { searchPostsData, searchPostsDataRefetch } = useFetchSearchPosts({
-    query: keyword,
-  });
-  const { allPostsData } = useFetchAllPosts();
+  const { allPostsData, isAllPostsLoading } = useFetchAllPosts();
+  const { searchPostsData, isSearchPostsLoading, searchPostsDataRefetch } =
+    useFetchSearchPosts({
+      query: keyword,
+    });
+
   const resultData = keyword
     ? getSortPostList(searchPostsData, sort, keyword)
     : getSortPostList(allPostsData, sort, keyword);
@@ -21,19 +24,24 @@ const PostList = ({ keyword, sort }: PostListProps) => {
   useEffect(() => {
     searchPostsDataRefetch();
   }, [keyword, searchPostsDataRefetch]);
+
+  // useEffect(() => {
+  //   allPostsRefetch();
+  // }, [sort, allPostsRefetch]);
   return (
-    <ul>
-      {resultData?.map((post) => (
-        <PostListItem
-          key={post._id}
-          id={post._id}
-          image={post.author.image}
-          title={post.title}
-          likes={post.likes.length}
-          comments={post.comments.length}
-        />
-      ))}
-    </ul>
+    <>
+      <ul>
+        {resultData?.map((post) => (
+          <PostListItem
+            key={post._id}
+            id={post._id}
+            image={post.author.image}
+            title={post.title}
+          />
+        ))}
+      </ul>
+      {(isAllPostsLoading || isSearchPostsLoading) && <Spinner />}
+    </>
   );
 };
 

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -18,8 +18,8 @@ const PostList = ({ keyword, sort }: PostListProps) => {
     });
 
   const resultData = keyword
-    ? getSortPostList(searchPostsData, sort, keyword)
-    : getSortPostList(allPostsData, sort, keyword);
+    ? getSortPostList(searchPostsData, sort)
+    : getSortPostList(allPostsData, sort);
 
   useEffect(() => {
     searchPostsDataRefetch();

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -25,9 +25,6 @@ const PostList = ({ keyword, sort }: PostListProps) => {
     searchPostsDataRefetch();
   }, [keyword, searchPostsDataRefetch]);
 
-  // useEffect(() => {
-  //   allPostsRefetch();
-  // }, [sort, allPostsRefetch]);
   return (
     <>
       <ul>

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import PostListItem from '@components/PostListItem';
+import Spinner from '@components/Spinner';
 import { useFetchAllPosts } from '@apis/post';
 import { useFetchSearchPosts } from '@apis/search';
 import { getSortPostList } from './utils';
@@ -10,10 +11,12 @@ interface PostListProps {
 }
 
 const PostList = ({ keyword, sort }: PostListProps) => {
-  const { searchPostsData, searchPostsDataRefetch } = useFetchSearchPosts({
-    query: keyword,
-  });
-  const { allPostsData } = useFetchAllPosts();
+  const { allPostsData, isAllPostsLoading } = useFetchAllPosts();
+  const { searchPostsData, isSearchPostsLoading, searchPostsDataRefetch } =
+    useFetchSearchPosts({
+      query: keyword,
+    });
+
   const resultData = keyword
     ? getSortPostList(searchPostsData, sort, keyword)
     : getSortPostList(allPostsData, sort, keyword);
@@ -21,17 +24,24 @@ const PostList = ({ keyword, sort }: PostListProps) => {
   useEffect(() => {
     searchPostsDataRefetch();
   }, [keyword, searchPostsDataRefetch]);
+
+  // useEffect(() => {
+  //   allPostsRefetch();
+  // }, [sort, allPostsRefetch]);
   return (
-    <ul>
-      {resultData?.map((post) => (
-        <PostListItem
-          key={post._id}
-          id={post._id}
-          image={post.author.image}
-          title={post.title}
-        />
-      ))}
-    </ul>
+    <>
+      <ul>
+        {resultData?.map((post) => (
+          <PostListItem
+            key={post._id}
+            id={post._id}
+            image={post.author.image}
+            title={post.title}
+          />
+        ))}
+      </ul>
+      {(isAllPostsLoading || isSearchPostsLoading) && <Spinner />}
+    </>
   );
 };
 

--- a/src/components/PostList/utils/index.ts
+++ b/src/components/PostList/utils/index.ts
@@ -3,10 +3,12 @@ import { Post } from '@type';
 export const getSortPostList = (
   searchData: Post[] | undefined,
   sort?: string,
-  keyword?: string,
 ): Post[] | undefined => {
-  if (sort === 'recent' && keyword) {
-    return searchData?.slice().reverse();
+  if (sort === 'recent') {
+    return searchData?.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
   } else if (sort === 'like') {
     return searchData?.sort((a, b) => b.likes.length - a.likes.length);
   }

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import Spinner from '@components/Spinner';
 import UserListItem from '@components/UserListItem';
 import { useFetchSearchUsers } from '@apis/search';
 import { useFetchUsers } from '@apis/user';
@@ -10,10 +11,11 @@ interface UserListProps {
 }
 
 const UserList = ({ keyword, sort }: UserListProps) => {
-  const { searchUsersData, searchUsersDataRefetch } = useFetchSearchUsers({
-    query: keyword,
-  });
-  const { usersData } = useFetchUsers();
+  const { usersData, isUsersLoading } = useFetchUsers();
+  const { searchUsersData, isSearchUsersLoading, searchUsersDataRefetch } =
+    useFetchSearchUsers({
+      query: keyword,
+    });
 
   const resultData = keyword
     ? getSortUserList(searchUsersData, sort)
@@ -24,18 +26,21 @@ const UserList = ({ keyword, sort }: UserListProps) => {
   }, [keyword, searchUsersDataRefetch]);
 
   return (
-    <ul>
-      {resultData?.map((user) => (
-        <UserListItem
-          key={user._id}
-          id={user._id}
-          image={user.image}
-          name={user.fullName}
-          likes={user.likes.length}
-          followers={user.followers.length}
-        />
-      ))}
-    </ul>
+    <>
+      <ul>
+        {resultData?.map((user) => (
+          <UserListItem
+            key={user._id}
+            id={user._id}
+            image={user.image}
+            name={user.fullName}
+            likes={user.likes.length}
+            followers={user.followers.length}
+          />
+        ))}
+      </ul>
+      {(isUsersLoading || isSearchUsersLoading) && <Spinner />}
+    </>
   );
 };
 

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -35,7 +35,7 @@ const UserList = ({ keyword, sort }: UserListProps) => {
             id={user._id}
             image={user.image}
             name={user.fullName}
-            likes={user.likes.length}
+            level={calculateLevel(user)}
             followers={user.followers.length}
             userEmoji={getUserLevelInfo(calculateLevel(user)).userEmoji}
             userColor={getUserLevelInfo(calculateLevel(user)).userColor}

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import Spinner from '@components/Spinner';
 import UserListItem from '@components/UserListItem';
 import { useFetchSearchUsers } from '@apis/search';
 import { useFetchUsers } from '@apis/user';
@@ -11,10 +12,11 @@ interface UserListProps {
 }
 
 const UserList = ({ keyword, sort }: UserListProps) => {
-  const { searchUsersData, searchUsersDataRefetch } = useFetchSearchUsers({
-    query: keyword,
-  });
-  const { usersData } = useFetchUsers();
+  const { usersData, isUsersLoading } = useFetchUsers();
+  const { searchUsersData, isSearchUsersLoading, searchUsersDataRefetch } =
+    useFetchSearchUsers({
+      query: keyword,
+    });
 
   const resultData = keyword
     ? getSortUserList(searchUsersData, sort)
@@ -25,20 +27,23 @@ const UserList = ({ keyword, sort }: UserListProps) => {
   }, [keyword, searchUsersDataRefetch]);
 
   return (
-    <ul>
-      {resultData?.map((user) => (
-        <UserListItem
-          key={user._id}
-          id={user._id}
-          image={user.image}
-          name={user.fullName}
-          likes={user.likes.length}
-          followers={user.followers.length}
-          userEmoji={getUserLevelInfo(calculateLevel(user)).userEmoji}
-          userColor={getUserLevelInfo(calculateLevel(user)).userColor}
-        />
-      ))}
-    </ul>
+    <>
+      <ul>
+        {resultData?.map((user) => (
+          <UserListItem
+            key={user._id}
+            id={user._id}
+            image={user.image}
+            name={user.fullName}
+            likes={user.likes.length}
+            followers={user.followers.length}
+            userEmoji={getUserLevelInfo(calculateLevel(user)).userEmoji}
+            userColor={getUserLevelInfo(calculateLevel(user)).userColor}
+          />
+        ))}
+      </ul>
+      {(isUsersLoading || isSearchUsersLoading) && <Spinner />}
+    </>
   );
 };
 

--- a/src/components/UserList/utils/index.ts
+++ b/src/components/UserList/utils/index.ts
@@ -1,4 +1,5 @@
 import { User } from '@type';
+import { calculateLevel } from '@utils/calculateUserLevel';
 
 export const getSortUserList = (
   searchData: User[] | undefined,
@@ -6,8 +7,8 @@ export const getSortUserList = (
 ): User[] | undefined => {
   if (sort === 'follower') {
     return searchData?.sort((a, b) => b.followers.length - a.followers.length);
-  } else if (sort === 'like') {
-    return searchData?.sort((a, b) => b.likes.length - a.likes.length);
+  } else if (sort === 'level') {
+    return searchData?.sort((a, b) => calculateLevel(b) - calculateLevel(a));
   }
   return searchData;
 };

--- a/src/components/UserListItem/index.tsx
+++ b/src/components/UserListItem/index.tsx
@@ -19,7 +19,7 @@ interface UserListItemProps {
   id: string;
   image: string;
   name: string;
-  likes: number;
+  level: number;
   followers: number;
   userEmoji: string;
   userColor: string;
@@ -29,7 +29,7 @@ const UserListItem = ({
   id,
   image,
   name,
-  likes,
+  level,
   followers,
   userEmoji,
   userColor,
@@ -71,11 +71,11 @@ const UserListItem = ({
         )}
       </div>
       <UserInfo>
-        <UserName color={userColor}>
-          {name} {userEmoji}
-        </UserName>
+        <UserName color={userColor}>{name}</UserName>
         <LikesAndFollowers>
-          <div>👍{likes}</div>
+          <div>
+            {userEmoji}Lv.{level}
+          </div>
           <div>🙍{followers}</div>
         </LikesAndFollowers>
       </UserInfo>


### PR DESCRIPTION
## 📑 구현 사항 

- [x] 유저 검색 페이지에서 최근 순 정렬 클릭 시 변경 되지 않는 문제 해결
- [x] 유저 검색 페이지에서 좋아요 순 정렬을 삭제
- [x] 검색 페이지에서 유저 레벨 순 정렬 구현
- [x] 유저 검색 페이지에서 유저 좋아요 수 대신 레벨을 렌더링 하도록 변경
- [x] Home 페이지는 더 이상 정렬을 사용하지 않으므로 정렬 select 제거

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/39931980/971c9f72-45a8-46bc-8da9-84e28b3a55ce)


<br/>

## 🚧 특이 사항


</br>

## 🚨관련 이슈
#63