### PR TITLE
[Component] - Button 컴포넌트 UI 수정

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,28 +1,39 @@
 import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
 
+// interface ButtonProps {
+//   text: string;
+//   disabled?: boolean;
+//   handleClick?: () => void;
+//   style?: CSSProperties;
+//   size?: 'sm' | 'md';
+// }
+
 interface ButtonProps {
-  text: string;
+  children?: string;
   disabled?: boolean;
   handleClick?: () => void;
   style?: CSSProperties;
   size?: 'sm' | 'md';
+  type?: 'button' | 'submit' | 'reset' | undefined;
 }
 
 const Button = ({
-  text,
-  handleClick,
+  children,
   disabled = false,
+  handleClick,
   style,
   size = 'sm',
+  type = 'submit',
 }: ButtonProps) => {
   return (
     <ButtonStyled
       size={size}
       disabled={disabled}
       onClick={handleClick}
-      style={style}>
-      {text}
+      style={style}
+      type={type}>
+      {children}
     </ButtonStyled>
   );
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
+import { ANGOLA_STYLES } from '@styles/commonStyles';
 
 interface ButtonProps {
   children?: string;
@@ -32,33 +33,28 @@ const Button = ({
 
 export default Button;
 
-// Todo(hayamaster): pxToRem util함수 구현 되면 import해서 적용시키기.
-const pxToRem = (pxValue: number) => {
-  return `${pxValue / 16}rem`;
-};
-
 const ButtonStyled = styled.button<{ size: string }>`
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
   align-items: flex-start;
-  height: ${pxToRem(88)};
-  padding: ${pxToRem(16)} ${pxToRem(24)};
-  background-color: #fff;
-  border-radius: ${pxToRem(44)};
-  border: ${pxToRem(2)} solid #404040;
+  height: 88px;
+  padding: 16px 24px;
+  background-color: ${ANGOLA_STYLES.color.white};
+  border-radius: 44px;
+  border: ${ANGOLA_STYLES.border.default};
 
   ${(props) =>
     props.size === 'sm'
-      ? `width: ${pxToRem(88)}; box-shadow: 0px 4px 0px 0px #404040;`
-      : `width: ${pxToRem(240)}; box-shadow: 0px 6px 0px 0px #404040;`}
+      ? `width: 88px; box-shadow: ${ANGOLA_STYLES.shadow.buttonSm.default};`
+      : `width: 240px; box-shadow: ${ANGOLA_STYLES.shadow.button.default};`}
 
   &:hover {
-    border: ${pxToRem(3)} solid #404040;
+    border: 3px solid ${ANGOLA_STYLES.color.text};
 
     ${(props) =>
       props.size === 'sm'
-        ? `box-shadow: 0px 6px 0px 0px #404040;`
-        : `box-shadow: 0px 10px 0px 0px #404040;`}
+        ? `box-shadow: ${ANGOLA_STYLES.shadow.buttonSm.hover};`
+        : `box-shadow: ${ANGOLA_STYLES.shadow.button.hover};`}
   }
 `;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,14 +1,6 @@
 import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
 
-// interface ButtonProps {
-//   text: string;
-//   disabled?: boolean;
-//   handleClick?: () => void;
-//   style?: CSSProperties;
-//   size?: 'sm' | 'md';
-// }
-
 interface ButtonProps {
   children?: string;
   disabled?: boolean;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,11 +6,19 @@ interface ButtonProps {
   disabled?: boolean;
   handleClick?: () => void;
   style?: CSSProperties;
+  size?: 'sm' | 'md';
 }
 
-const Button = ({ text, handleClick, disabled = false, style }: ButtonProps) => {
+const Button = ({
+  text,
+  handleClick,
+  disabled = false,
+  style,
+  size = 'sm',
+}: ButtonProps) => {
   return (
     <ButtonStyled
+      size={size}
       disabled={disabled}
       onClick={handleClick}
       style={style}>
@@ -21,15 +29,33 @@ const Button = ({ text, handleClick, disabled = false, style }: ButtonProps) => 
 
 export default Button;
 
-const ButtonStyled = styled.button`
-  border-radius: 54px;
-  width: 100px;
-  height: 30px;
-  border: 4px solid black;
-  background-color: white;
-  font-size: 20px;
+// Todo(hayamaster): pxToRem util함수 구현 되면 import해서 적용시키기.
+const pxToRem = (pxValue: number) => {
+  return `${pxValue / 16}rem`;
+};
+
+const ButtonStyled = styled.button<{ size: string }>`
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  align-items: flex-start;
+  height: ${pxToRem(88)};
+  padding: ${pxToRem(16)} ${pxToRem(24)};
+  background-color: #fff;
+  border-radius: ${pxToRem(44)};
+  border: ${pxToRem(2)} solid #404040;
+
+  ${(props) =>
+    props.size === 'sm'
+      ? `width: ${pxToRem(88)}; box-shadow: 0px 4px 0px 0px #404040;`
+      : `width: ${pxToRem(240)}; box-shadow: 0px 6px 0px 0px #404040;`}
 
   &:hover {
-    background-color: rgba(60, 100, 105, 0.3);
+    border: ${pxToRem(3)} solid #404040;
+
+    ${(props) =>
+      props.size === 'sm'
+        ? `box-shadow: 0px 6px 0px 0px #404040;`
+        : `box-shadow: 0px 10px 0px 0px #404040;`}
   }
 `;


### PR DESCRIPTION
## 📑 구현 사항 

- [x] size가 sm 또는 md에 따라 UI style 구현하기
- [x] props 수정하기 
- [x] 디자인 상수 적용 완료

<br/>

## 🚧 특이 사항

figma에 button 디자인 수정 후, button 컴포넌트를 small size와 middle size로 분리시켜 디자인을 적용시켰습니다.
```javascript
interface ButtonProps {
  children?: string;
  disabled?: boolean;
  handleClick?: () => void;
  style?: CSSProperties;
  size?: 'sm' | 'md';
  type?: 'button' | 'submit' | 'reset' | undefined;
}
```
Button 컴포넌트의 props 중 size를 옵션으로 받을 수 있게 구현했습니다. 기본 값은 'sm' (small)입니다.
기존에 props로 받아왔던 text대신 children으로 변경하였습니다.
props으로 type을 받을 수 있게 하였습니다. 기본 값은 submit입니다. 

</br>

## 🚨관련 이슈

#24 