### PR TITLE
[Style] - resetCSS, commonCSS 겹침으로 인한 스타일 적용 안되는 문제 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ export default App;
 const PageContainer = styled.div`
   box-sizing: border-box;
   display: flex;
+  padding: 0 80px;
   flex-direction: column;
   align-items: center;
   width: 100%; 

--- a/src/styles/commonStyles.css
+++ b/src/styles/commonStyles.css
@@ -7,7 +7,6 @@
 
 body {
   background-color: #e5e5e5;
-  padding: 0 80px;
 }
 
 * {


### PR DESCRIPTION
## 📑 구현 사항 

- [x] resetCSS, commonCSS 겹침으로 인한 스타일 적용 안되는 문제 해결
 => body의 padding pageContainer로 이동

<br/>

## 🚨관련 이슈
#91 