### PR TITLE
[Style] - 검색 페이지 style 추가

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
 
@@ -5,6 +6,7 @@ interface ImageProps {
   src: string;
   alt: string;
   size?: number;
+  style?: CSSProperties;
 }
 
 const Image = ({ src, alt, size = 150, ...props }: ImageProps) => {

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import styled from '@emotion/styled';
 import PostListItem from '@components/PostListItem';
 import Spinner from '@components/Spinner';
 import { useFetchAllPosts } from '@apis/post';
@@ -27,19 +28,29 @@ const PostList = ({ keyword, sort }: PostListProps) => {
 
   return (
     <>
-      <ul>
+      <PostListItems>
         {resultData?.map((post) => (
           <PostListItem
             key={post._id}
             id={post._id}
             image={post.author.image}
             title={post.title}
+            likes={post.likes.length}
+            comments={post.comments.length}
           />
         ))}
-      </ul>
+      </PostListItems>
       {(isAllPostsLoading || isSearchPostsLoading) && <Spinner />}
     </>
   );
 };
 
 export default PostList;
+
+const PostListItems = styled.ul`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+`;

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -8,6 +8,7 @@ import Modal from '@components/Modal';
 import { useFetchDeletePost, useFetchUserPosts } from '@apis/post';
 import { authInfoState } from '@store/auth';
 import { splitPostBySeparator } from '@utils/parseDataBySeparator';
+import { ANGOLA_STYLES } from '@styles/commonStyles';
 
 interface PostListItemProps {
   id: string;
@@ -53,20 +54,20 @@ const PostListItem = ({
 
   return (
     <ListItemContainer>
-      <img
+      <ProfileImage
         src={
           image
             ? image
             : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
         }
-        alt="프로필"
-        style={{ width: '70px', height: '70px', borderRadius: '50%' }}
-      />
-      <Title>{postTitle}</Title>
-      <Info>
-        <div>♥️{likes}</div>
-        <div>💬{comments}</div>
-      </Info>
+        alt="프로필"></ProfileImage>
+      <TitleContainer>
+        <Title>{postTitle}</Title>
+      </TitleContainer>
+      <LikesAndComments>
+        <div>♥️ {likes}</div>
+        <div>💬 {comments}</div>
+      </LikesAndComments>
       <More>
         <LinkButton
           to={`/post/${id}`}
@@ -96,36 +97,53 @@ export default PostListItem;
 
 const ListItemContainer = styled.li`
   display: flex;
-  border: 1px solid black;
-  margin: 30px 0;
-  gap: 20px;
-  border-radius: 12px;
+  height: 100px;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  border-radius: 24px;
+  border: ${ANGOLA_STYLES.border.default};
+  background: #fff;
+  box-shadow: 0px 6px 0px 0px #404040;
+`;
+
+const ProfileImage = styled.img`
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: ${ANGOLA_STYLES.border.default};
+  margin: 0px 20px;
+  background: #9a9a9a;
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+  padding: 16px 32px;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+  border-radius: 24px;
+  background: #e5e5e5;
 `;
 
 const Title = styled.div`
-  border: 1px solid black;
-  border-radius: 30px;
-  flex-grow: 1;
+  color: #404040;
+  font-size: ${ANGOLA_STYLES.textSize.titleSm};
+`;
+
+const LikesAndComments = styled.div`
   display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 14px 0;
+  flex-direction: column;
+  gap: 12px;
+  font-size: ${ANGOLA_STYLES.textSize.title};
 `;
 
 const More = styled.div`
-  border-left: 1px solid black;
   display: flex;
+  width: 121px;
   justify-content: center;
-  align-items: center;
-  width: 60px;
+  align-self: stretch;
+  border-left: ${ANGOLA_STYLES.border.default};
+  font-size: ${ANGOLA_STYLES.textSize.title};
   cursor: pointer;
-`;
-
-const Info = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-end;
-  gap: 10px;
-  flex-shrink: 0;
 `;

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { MORE_LINK_BUTTON_STYLES } from '@styles';
 import { useRecoilValue } from 'recoil';
 import Icon from '@components/Icon';
+import Image from '@components/Image';
 import LinkButton from '@components/LinkButton';
 import Modal from '@components/Modal';
 import { useFetchDeletePost, useFetchUserPosts } from '@apis/post';
@@ -54,32 +55,45 @@ const PostListItem = ({
 
   return (
     <ListItemContainer>
-      <ProfileImage
+      <Image
         src={
           image
             ? image
             : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
         }
-        alt="프로필"></ProfileImage>
+        alt="프로필"
+        size={60}
+        style={{ margin: '0 20px' }}></Image>
       <TitleContainer>
         <Title>{postTitle}</Title>
       </TitleContainer>
-      <LikesAndComments>
-        <div>♥️ {likes}</div>
-        <div>💬 {comments}</div>
-      </LikesAndComments>
-      <More>
+      {canDeletePost ? (
+        <DeleteButton onClick={handleOpenModal}>
+          <Icon name="trash" />
+        </DeleteButton>
+      ) : (
+        <LikesAndComments>
+          <div>
+            <Icon name="heart" /> {likes}
+          </div>
+          <div>
+            <Icon name="comment" /> {comments}
+          </div>
+        </LikesAndComments>
+      )}
+
+      <More className="more">
         <LinkButton
           to={`/post/${id}`}
           style={MORE_LINK_BUTTON_STYLES}>
           More
         </LinkButton>
       </More>
-      {canDeletePost ? (
+      {/* {canDeletePost ? (
         <button onClick={handleOpenModal}>
           <Icon name="trash" />
         </button>
-      ) : null}
+      ) : null} */}
       {toggleModal && (
         <Modal
           onClose={handleCloseModal}
@@ -103,17 +117,12 @@ const ListItemContainer = styled.li`
   width: 100%;
   border-radius: 24px;
   border: ${ANGOLA_STYLES.border.default};
-  background: #fff;
-  box-shadow: 0px 6px 0px 0px #404040;
-`;
-
-const ProfileImage = styled.img`
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-  border: ${ANGOLA_STYLES.border.default};
-  margin: 0px 20px;
-  background: #9a9a9a;
+  background: ${ANGOLA_STYLES.color.white};
+  box-shadow: ${ANGOLA_STYLES.shadow.button.default};
+  overflow: hidden;
+  &:has(.more:hover) {
+    box-shadow: ${ANGOLA_STYLES.shadow.button.hover};
+  }
 `;
 
 const TitleContainer = styled.div`
@@ -127,7 +136,7 @@ const TitleContainer = styled.div`
 `;
 
 const Title = styled.div`
-  color: #404040;
+  color: ${ANGOLA_STYLES.color.text};
   font-size: ${ANGOLA_STYLES.textSize.titleSm};
 `;
 
@@ -136,6 +145,22 @@ const LikesAndComments = styled.div`
   flex-direction: column;
   gap: 12px;
   font-size: ${ANGOLA_STYLES.textSize.title};
+`;
+
+const DeleteButton = styled.div`
+  display: flex;
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 44px;
+  border: ${ANGOLA_STYLES.border.default};
+  background: ${ANGOLA_STYLES.color.white};
+  box-shadow: ${ANGOLA_STYLES.shadow.buttonSm.default};
+  cursor: pointer;
+  &:hover {
+    box-shadow: ${ANGOLA_STYLES.shadow.buttonSm.hover};
+  }
 `;
 
 const More = styled.div`

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -63,7 +63,8 @@ const PostListItem = ({
         }
         alt="프로필"
         size={60}
-        style={{ margin: '0 20px' }}></Image>
+        style={{ margin: '0 20px' }}
+      />
       <TitleContainer>
         <Title>{postTitle}</Title>
       </TitleContainer>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import styled from '@emotion/styled';
 import { calculateLevel, getUserLevelInfo } from '@utils';
 import Spinner from '@components/Spinner';
 import UserListItem from '@components/UserListItem';
@@ -28,7 +29,7 @@ const UserList = ({ keyword, sort }: UserListProps) => {
 
   return (
     <>
-      <ul>
+      <UserListItems>
         {resultData?.map((user) => (
           <UserListItem
             key={user._id}
@@ -38,13 +39,20 @@ const UserList = ({ keyword, sort }: UserListProps) => {
             level={calculateLevel(user)}
             followers={user.followers.length}
             userEmoji={getUserLevelInfo(calculateLevel(user)).userEmoji}
-            userColor={getUserLevelInfo(calculateLevel(user)).userColor}
           />
         ))}
-      </ul>
+      </UserListItems>
       {(isUsersLoading || isSearchUsersLoading) && <Spinner />}
     </>
   );
 };
 
 export default UserList;
+
+const UserListItems = styled.ul`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+`;

--- a/src/components/UserListItem/index.tsx
+++ b/src/components/UserListItem/index.tsx
@@ -1,22 +1,12 @@
-import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 import Icon from '@components/Icon';
+import Image from '@components/Image';
 import LinkButton from '@components/LinkButton';
 import NameTag from '@components/NameTag';
 import { authInfoState } from '@store/auth';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
 import { MORE_LINK_BUTTON_STYLES } from '@styles/index';
-
-const PROFILE_LINK_BUTTON_STYLES: CSSProperties = {
-  all: 'unset',
-  display: 'flex',
-  width: 50,
-  height: 50,
-  justifyContent: 'center',
-  alignItems: 'center',
-  borderRadius: '50%',
-};
 
 interface UserListItemProps {
   id: string;
@@ -40,41 +30,27 @@ const UserListItem = ({
 
   return (
     <ListItemContainer>
-      {myId === id ? (
-        <LinkButton
-          to={`/mypage`}
-          style={PROFILE_LINK_BUTTON_STYLES}>
-          <ProfileImage
-            src={
-              image
-                ? image
-                : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
-            }
-            alt="프로필"
-          />
-        </LinkButton>
-      ) : (
-        <LinkButton
-          to={`/user/${id}`}
-          style={PROFILE_LINK_BUTTON_STYLES}>
-          <ProfileImage
-            src={
-              image
-                ? image
-                : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
-            }
-            alt="프로필"
-          />
-        </LinkButton>
-      )}
+      <Image
+        src={
+          image
+            ? image
+            : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
+        }
+        alt="프로필"
+        size={60}
+        style={{ margin: '0 20px' }}
+      />
       <UserInfo>
-        <NameTag
-          level={level}
-          userName={name}
-          userId={id}
-          userLevel={level}
-          isNav={true}
-          showLevel={false}></NameTag>
+        <div className="user_name">
+          <NameTag
+            level={level}
+            userName={name}
+            userId={id}
+            userLevel={level}
+            isNav={true}
+            showLevel={false}></NameTag>
+        </div>
+
         <LevelAndFollowers>
           <div>
             {userEmoji} Lv.{level}
@@ -84,7 +60,7 @@ const UserListItem = ({
           </div>
         </LevelAndFollowers>
       </UserInfo>
-      <More>
+      <More className="more">
         {myId === id ? (
           <LinkButton
             to={`/mypage`}
@@ -113,17 +89,12 @@ const ListItemContainer = styled.li`
   width: 100%;
   border-radius: 24px;
   border: ${ANGOLA_STYLES.border.default};
-  background: #fff;
-  box-shadow: 0px 6px 0px 0px #404040;
-`;
-
-const ProfileImage = styled.img`
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-  border: ${ANGOLA_STYLES.border.default};
-  margin: 0px 20px;
-  background: #9a9a9a;
+  background: ${ANGOLA_STYLES.color.white};
+  box-shadow: ${ANGOLA_STYLES.shadow.button.default};
+  overflow: hidden;
+  &:has(.user_name:hover, .more:hover) {
+    box-shadow: ${ANGOLA_STYLES.shadow.button.hover};
+  }
 `;
 
 const UserInfo = styled.div`

--- a/src/components/UserListItem/index.tsx
+++ b/src/components/UserListItem/index.tsx
@@ -1,8 +1,11 @@
 import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
+import Icon from '@components/Icon';
 import LinkButton from '@components/LinkButton';
+import NameTag from '@components/NameTag';
 import { authInfoState } from '@store/auth';
+import { ANGOLA_STYLES } from '@styles/commonStyles';
 import { MORE_LINK_BUTTON_STYLES } from '@styles/index';
 
 const PROFILE_LINK_BUTTON_STYLES: CSSProperties = {
@@ -22,7 +25,6 @@ interface UserListItemProps {
   level: number;
   followers: number;
   userEmoji: string;
-  userColor: string;
 }
 
 const UserListItem = ({
@@ -32,52 +34,55 @@ const UserListItem = ({
   level,
   followers,
   userEmoji,
-  userColor,
 }: UserListItemProps) => {
   const auth = useRecoilValue(authInfoState);
   const myId = auth?.userId;
 
   return (
-    <List>
-      <div>
-        {myId === id ? (
-          <LinkButton
-            to={`/mypage`}
-            style={PROFILE_LINK_BUTTON_STYLES}>
-            <img
-              src={
-                image
-                  ? image
-                  : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
-              }
-              alt="프로필"
-              style={{ width: '70px', height: '70px', borderRadius: '50%' }}
-            />
-          </LinkButton>
-        ) : (
-          <LinkButton
-            to={`/user/${id}`}
-            style={PROFILE_LINK_BUTTON_STYLES}>
-            <img
-              src={
-                image
-                  ? image
-                  : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
-              }
-              alt="프로필"
-              style={{ width: '70px', height: '70px', borderRadius: '50%' }}
-            />
-          </LinkButton>
-        )}
-      </div>
+    <ListItemContainer>
+      {myId === id ? (
+        <LinkButton
+          to={`/mypage`}
+          style={PROFILE_LINK_BUTTON_STYLES}>
+          <ProfileImage
+            src={
+              image
+                ? image
+                : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
+            }
+            alt="프로필"
+          />
+        </LinkButton>
+      ) : (
+        <LinkButton
+          to={`/user/${id}`}
+          style={PROFILE_LINK_BUTTON_STYLES}>
+          <ProfileImage
+            src={
+              image
+                ? image
+                : 'https://hips.hearstapps.com/hmg-prod/images/russian-blue-royalty-free-image-1658451809.jpg?crop=0.667xw:1.00xh;0.128xw,0&resize=980:*'
+            }
+            alt="프로필"
+          />
+        </LinkButton>
+      )}
       <UserInfo>
-        <UserName color={userColor}>{name}</UserName>
-        <LikesAndFollowers>
+        <NameTag
+          level={level}
+          userName={name}
+          userId={id}
+          userLevel={level}
+          isNav={true}
+          showLevel={false}></NameTag>
+        <LevelAndFollowers>
           <div>
-            {userEmoji}Lv.{level}
+            {userEmoji} Lv.{level}
           </div>
-          <div>🙍{followers}</div>
-        </LikesAndFollowers>
+          <div>
+            <Icon name="follower" /> {followers}
+          </div>
+        </LevelAndFollowers>
       </UserInfo>
       <More>
         {myId === id ? (
@@ -94,44 +99,54 @@ const UserListItem = ({
           </LinkButton>
         )}
       </More>
-    </List>
+    </ListItemContainer>
   );
 };
 
 export default UserListItem;
 
-const List = styled.li`
+const ListItemContainer = styled.li`
   display: flex;
-  border: 1px solid black;
-  margin: 30px 0;
-  gap: 20px;
-  border-radius: 12px;
+  height: 100px;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  border-radius: 24px;
+  border: ${ANGOLA_STYLES.border.default};
+  background: #fff;
+  box-shadow: 0px 6px 0px 0px #404040;
+`;
+
+const ProfileImage = styled.img`
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: ${ANGOLA_STYLES.border.default};
+  margin: 0px 20px;
+  background: #9a9a9a;
 `;
 
 const UserInfo = styled.div`
-  flex-grow: 1;
   display: flex;
+  padding: 12px 0px;
   justify-content: space-between;
   align-items: center;
-  margin: 14px 0;
+  flex-grow: 1;
 `;
 
-const UserName = styled.div`
-  font-weight: 600;
-  color: ${(props) => props.color};
-`;
-
-const LikesAndFollowers = styled.div`
+const LevelAndFollowers = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
+  font-size: ${ANGOLA_STYLES.textSize.title};
 `;
 
 const More = styled.div`
-  border-left: 1px solid black;
   display: flex;
+  width: 121px;
   justify-content: center;
-  align-items: center;
-  width: 60px;
+  align-self: stretch;
+  border-left: ${ANGOLA_STYLES.border.default};
+  font-size: ${ANGOLA_STYLES.textSize.title};
   cursor: pointer;
 `;

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -29,8 +29,5 @@ const SearchPage = ({ target = 'post', keyword, sort }: SearchProps) => {
 export default SearchPage;
 
 const Container = styled.div`
-  width: 80%;
-  border: 1px solid black;
-  border-top: none;
-  padding: 20px 10px;
+  width: 100%;
 `;


### PR DESCRIPTION
## 📑 구현 사항 

- [x]  검색 페이지 디자인 적용
- [x] UserList, UserListItem, PostList, PostListItem 컴포넌트 디자인 적용

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/39931980/3d5dfc09-4fdb-4d56-b1a4-980f223b2f06)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/39931980/929051a5-91db-4caa-81b8-a2aa7c0be75c)

<br/>

## 🚧 특이 사항
- Image 컴포넌트에 style prop 추가
- canDeletePost가 false일 때 좋아요, 댓글 개수를 true일 때 delete 버튼이 렌더링 되게 적용 (마이 페이지에서는 기존 코드 그대로 사용하시면 됩니다!)
- post 검색은 More 버튼, user 검색은 NameTag, More 버튼으로 이동할 수 있게 변경




</br>

## 🚨관련 이슈

#87 