### PR TITLE
[Feat] - UserPage 팔로우 에러 처리, 반응형 추가

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -59,7 +59,7 @@ export const ButtonStyled = styled.button<ButtonProps>`
 
   &:disabled {
     border: ${ANGOLA_STYLES.border.default};
-    background-color: ${ANGOLA_STYLES.color.gray};
+    background-color: ${ANGOLA_STYLES.color.dark};
     box-shadow: ${ANGOLA_STYLES.shadow.button.default};
     cursor: default;
   }

--- a/src/pages/UserPage/UserInfo.tsx
+++ b/src/pages/UserPage/UserInfo.tsx
@@ -8,7 +8,7 @@ import Spinner from '@components/Spinner';
 import { authInfoState } from '@store/auth';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
 import { USER_INFO, USER_PROFILE_IMAGE } from '@constants/index';
-import { FOLLOW_MESSAGE } from './constants';
+import { FOLLOW_ERROR_MESSAGE, FOLLOW_MESSAGE } from './constants';
 import useFollow from './hooks/useFollow';
 
 interface UserInfoProps {
@@ -99,12 +99,12 @@ const UserInfo = ({
         )}
         {isFollowModalOpen && (
           <Modal onClose={() => setIsFollowModalOpen(false)}>
-            팔로우 신청에 실패했습니다.
+            {FOLLOW_ERROR_MESSAGE.FOLLOW}
           </Modal>
         )}
         {isUnFollowModalOpen && (
           <Modal onClose={() => setIsUnFollowModalOpen(false)}>
-            팔로우 취소에 실패했습니다.
+            {FOLLOW_ERROR_MESSAGE.UN_FOLLOW}
           </Modal>
         )}
       </UserInfoContainer>

--- a/src/pages/UserPage/UserInfo.tsx
+++ b/src/pages/UserPage/UserInfo.tsx
@@ -45,7 +45,7 @@ const UserInfo = ({
     isUnFollowModalOpen,
     setIsFollowModalOpen,
     setIsUnFollowModalOpen,
-    changeButton,
+    disabledFollowButton,
   } = useFollow({
     userId,
     followers,
@@ -91,7 +91,7 @@ const UserInfo = ({
             toggle={isFollowed}
             size="md"
             onClick={handleClickFollowButton}
-            disabled={changeButton()}>
+            disabled={disabledFollowButton()}>
             {isFollowed
               ? `${FOLLOW_MESSAGE.UN_FOLLOW}`
               : `${FOLLOW_MESSAGE.FOLLOW}`}

--- a/src/pages/UserPage/UserInfo.tsx
+++ b/src/pages/UserPage/UserInfo.tsx
@@ -149,6 +149,11 @@ const UserInfoContainer = styled.div`
   padding: 12px 0px;
   gap: 24px;
   align-self: stretch;
+
+  @media (max-width: 1024px) {
+    gap: 20px;
+    flex-direction: column;
+  }
 `;
 
 const UserInfoText = styled.div`
@@ -168,4 +173,8 @@ const Bar = styled.div`
   font-weight: 600;
   line-height: 150%;
   letter-spacing: -0.396px;
+
+  @media (max-width: 1024px) {
+    display: none;
+  }
 `;

--- a/src/pages/UserPage/UserInfo.tsx
+++ b/src/pages/UserPage/UserInfo.tsx
@@ -2,7 +2,9 @@ import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 import Button from '@components/Button';
 import Image from '@components/Image';
+import Modal from '@components/Modal';
 import NameTag from '@components/NameTag';
+import Spinner from '@components/Spinner';
 import { authInfoState } from '@store/auth';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
 import { USER_INFO, USER_PROFILE_IMAGE } from '@constants/index';
@@ -33,7 +35,18 @@ const UserInfo = ({
   userEmoji,
 }: UserInfoProps) => {
   const auth = useRecoilValue(authInfoState);
-  const { countFollowers, handleClickFollowButton, isFollowed } = useFollow({
+  const {
+    countFollowers,
+    handleClickFollowButton,
+    isFollowed,
+    isFollowLoading,
+    isUnFollowLoading,
+    isFollowModalOpen,
+    isUnFollowModalOpen,
+    setIsFollowModalOpen,
+    setIsUnFollowModalOpen,
+    changeButton,
+  } = useFollow({
     userId,
     followers,
     followerId,
@@ -72,15 +85,27 @@ const UserInfo = ({
         <UserInfoText>
           {USER_INFO.GET_LIKES}&nbsp;&nbsp;{likes}
         </UserInfoText>
+        {(isFollowLoading || isUnFollowLoading) ?? <Spinner />}
         {auth && (
           <Button
             toggle={isFollowed}
             size="md"
-            onClick={handleClickFollowButton}>
+            onClick={handleClickFollowButton}
+            disabled={changeButton()}>
             {isFollowed
               ? `${FOLLOW_MESSAGE.UN_FOLLOW}`
               : `${FOLLOW_MESSAGE.FOLLOW}`}
           </Button>
+        )}
+        {isFollowModalOpen && (
+          <Modal onClose={() => setIsFollowModalOpen(false)}>
+            팔로우 신청에 실패했습니다.
+          </Modal>
+        )}
+        {isUnFollowModalOpen && (
+          <Modal onClose={() => setIsUnFollowModalOpen(false)}>
+            팔로우 취소에 실패했습니다.
+          </Modal>
         )}
       </UserInfoContainer>
     </UserInfoWrapper>

--- a/src/pages/UserPage/constants/index.ts
+++ b/src/pages/UserPage/constants/index.ts
@@ -2,3 +2,8 @@ export const FOLLOW_MESSAGE = {
   FOLLOW: '팔로우 하기',
   UN_FOLLOW: '언팔로우 하기',
 };
+
+export const FOLLOW_ERROR_MESSAGE = {
+  FOLLOW: '팔로우 신청에 실패했습니다.',
+  UN_FOLLOW: '팔로우 취소에 실패했습니다.',
+};

--- a/src/pages/UserPage/hooks/useFollow.ts
+++ b/src/pages/UserPage/hooks/useFollow.ts
@@ -54,7 +54,7 @@ const useFollow = ({ userId, followers, followerId }: useFollowProps) => {
     }
   }, [isFollowError, isUnFollowError]);
 
-  const changeButton = () => {
+  const disabledFollowButton = () => {
     if (isFollowError || isUnFollowError) {
       return true;
     } else {
@@ -72,7 +72,7 @@ const useFollow = ({ userId, followers, followerId }: useFollowProps) => {
     isUnFollowModalOpen,
     setIsFollowModalOpen,
     setIsUnFollowModalOpen,
-    changeButton,
+    disabledFollowButton,
   };
 };
 

--- a/src/pages/UserPage/hooks/useFollow.ts
+++ b/src/pages/UserPage/hooks/useFollow.ts
@@ -8,11 +8,15 @@ interface useFollowProps {
 }
 
 const useFollow = ({ userId, followers, followerId }: useFollowProps) => {
-  const { followMutate, followData } = useFetchFollow();
-  const { unFollowMutate } = useFetchUnFollow();
+  const { followMutate, followData, isFollowLoading, isFollowError } =
+    useFetchFollow();
+  const { unFollowMutate, isUnFollowLoading, isUnFollowError } =
+    useFetchUnFollow();
   const [userFollowerId, setUserFollowerId] = useState(followerId);
   const [countFollowers, setCountFollowers] = useState(followers);
   const [isFollowed, setIsFollowed] = useState(followerId !== undefined);
+  const [isFollowModalOpen, setIsFollowModalOpen] = useState(false);
+  const [isUnFollowModalOpen, setIsUnFollowModalOpen] = useState(false);
 
   useEffect(() => {
     setCountFollowers(followers);
@@ -39,10 +43,36 @@ const useFollow = ({ userId, followers, followerId }: useFollowProps) => {
     }
   }, [followData.followId, isFollowed]);
 
+  useEffect(() => {
+    if (isFollowError) {
+      setCountFollowers((prev) => prev - 1);
+      setIsFollowModalOpen(true);
+    }
+    if (isUnFollowError) {
+      setCountFollowers((prev) => prev + 1);
+      setIsUnFollowModalOpen(true);
+    }
+  }, [isFollowError, isUnFollowError]);
+
+  const changeButton = () => {
+    if (isFollowError || isUnFollowError) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   return {
     countFollowers,
     handleClickFollowButton,
     isFollowed,
+    isFollowLoading,
+    isUnFollowLoading,
+    isFollowModalOpen,
+    isUnFollowModalOpen,
+    setIsFollowModalOpen,
+    setIsUnFollowModalOpen,
+    changeButton,
   };
 };
 

--- a/src/pages/UserPage/index.tsx
+++ b/src/pages/UserPage/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { calculateLevel, getUserLevelInfo } from '@utils';
@@ -18,7 +19,11 @@ interface UserPageProps {
 const UserPage = ({ userId = '' }: UserPageProps) => {
   const auth = useRecoilValue(authInfoState);
   const navigate = useNavigate();
-  const { userData, isUserLoading } = useFetchUser(userId);
+  const { userData, isUserLoading, userDataRefetch } = useFetchUser(userId);
+
+  useEffect(() => {
+    userDataRefetch();
+  }, [userId]);
 
   if (userId === auth?.userId) {
     navigate('/mypage', { replace: true });

--- a/src/pages/UserPage/index.tsx
+++ b/src/pages/UserPage/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { calculateLevel, getUserLevelInfo } from '@utils';
@@ -18,7 +19,11 @@ interface UserPageProps {
 const UserPage = ({ userId = '' }: UserPageProps) => {
   const auth = useRecoilValue(authInfoState);
   const navigate = useNavigate();
-  const { userData, isUserLoading } = useFetchUser(userId);
+  const { userData, isUserLoading, userDataRefetch } = useFetchUser(userId);
+
+  useEffect(() => {
+    userDataRefetch();
+  }, [userId, userDataRefetch]);
 
   if (userId === auth?.userId) {
     navigate('/mypage', { replace: true });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,8 +6,7 @@ import {
   PostPage,
   SearchPage,
   SignUpPage,
-UserPage,
-
+  UserPage,
 } from '@pages';
 import type { Params, SearchParams } from '@hooks/useCurrentPage';
 


### PR DESCRIPTION
## 📑 구현 사항 

- [x] 팔로우 등록 / 취소 실패 시 모달창 발생하고, 팔로우 버튼 막기
- [x] 유저 페이지 반응형

## 🚧 특이 사항
- 팔로우 등록 / 취소 실패 시 state로 관리 해서 그런가.. 실패해도 숫자 변화가 생겨셔,
뾰족한 수가 떠오르지 않아.. 실패 시 증가 되거나 감소 한 수를 다시  뺴주거나 더해줬습니다 ㅠ 
이후에는 추가적으로 팔로우 기능을 사용하지 못하도록 버튼을 disabled 시켜줬습니다.

-  버튼 disabled 색상 변경 (gray -> dark)

## 🚨관련 이슈

#132