### PR TITLE
[Feat] - 레벨업 감지 기능 및 축하 컴포넌트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.5.0",
         "emotion-rgba": "^0.0.12",
         "react": "^18.2.0",
+        "react-canvas-confetti": "^1.4.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
         "react-query": "^3.39.3",
@@ -1230,6 +1231,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.6.0.tgz",
+      "integrity": "sha512-Yq6rIccwcco0TLD5SMUrIM7Fk7Fe/C0jmNRxJJCLtAF6gebDkPuUjK5EHedxecm69Pi/aA+It39Ux4OHmFhjRw=="
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
@@ -1701,6 +1707,15 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.6.0.tgz",
+      "integrity": "sha512-ej+w/m8Jzpv9Z7W7uJZer14Ke8P2ogsjg4ZMGIuq4iqUOqY2Jq8BNW42iGmNfRwREaaEfFIczLuZZiEVSYNHAA==",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -3084,6 +3099,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-canvas-confetti": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-canvas-confetti/-/react-canvas-confetti-1.4.0.tgz",
+      "integrity": "sha512-ByBdSsNGUxlcJuOqSgbZw1VWNNO3b7njTmnuM1Y36mvwdCkCRs8rLkRAjn6MQK96LgWcfDVhr6ZT5olm2w8Zwg==",
+      "dependencies": {
+        "@types/canvas-confetti": "1.6.0",
+        "canvas-confetti": "1.6.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.5.0",
     "emotion-rgba": "^0.0.12",
     "react": "^18.2.0",
+    "react-canvas-confetti": "^1.4.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
     "react-query": "^3.39.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ const App = () => {
     <BrowserRouter>
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>
-          <PageContainer>
+          <PageContainer id="app">
             <NavBar />
             <Main />
           </PageContainer>
@@ -30,7 +30,7 @@ const PageContainer = styled.div`
   padding: 0 80px;
   flex-direction: column;
   align-items: center;
-  width: 100%; 
-  height: 100%; 
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 `;

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -3,6 +3,7 @@ import { User } from '@type';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useSetRecoilState } from 'recoil';
 import { authInfoState } from '@store/auth';
+import { userArchives } from '@store/level';
 import useAxiosInstance from './instance';
 
 interface SignUpRequestBody {
@@ -38,6 +39,7 @@ interface LoginResponse {
 export const useFetchLogin = () => {
   const { baseInstance } = useAxiosInstance();
   const setAuth = useSetRecoilState(authInfoState);
+  const setUserArchives = useSetRecoilState(userArchives);
 
   const { mutate, data, isSuccess, isError, isLoading } = useMutation<
     AxiosResponse<LoginResponse>,
@@ -48,6 +50,10 @@ export const useFetchLogin = () => {
       setAuth({
         userId: data.user._id,
         token: data.token,
+      });
+      setUserArchives({
+        commentsLength: data.user.comments.length,
+        postsLength: data.user.posts.length,
       });
     },
   });

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -50,6 +50,7 @@ export const useFetchLogin = () => {
       setAuth({
         userId: data.user._id,
         token: data.token,
+        userFullName: data.user.fullName,
       });
       setUserArchives({
         commentsLength: data.user.comments.length,

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -1,4 +1,5 @@
 import { useMutation } from 'react-query';
+import { useArchives } from '@hooks/useArchives';
 import useAxiosInstance from './instance';
 
 interface CreateCommentRequestBody {
@@ -9,12 +10,19 @@ interface CreateCommentRequestBody {
 export const useFetchCreateComment = () => {
   const { authInstance } = useAxiosInstance();
 
+  const { addCommentArchive } = useArchives();
+
   const fetcher = (body: CreateCommentRequestBody) =>
     authInstance.post('/comments/create', body);
 
   const { mutate, isLoading, isError, isSuccess } = useMutation(
     'createCommentMutation',
     fetcher,
+    {
+      onSuccess: () => {
+        addCommentArchive();
+      },
+    },
   );
 
   return {
@@ -32,12 +40,19 @@ interface DeleteCommentRequestBody {
 export const useFetchDeleteComment = () => {
   const { authInstance } = useAxiosInstance();
 
+  const { removeCommentArchive } = useArchives();
+
   const fetcher = (body: DeleteCommentRequestBody) =>
     authInstance.delete('/comments/delete', { data: body });
 
   const { mutate, isLoading, isError, isSuccess } = useMutation(
     'deleteCommentMutation',
     fetcher,
+    {
+      onSuccess: () => {
+        removeCommentArchive();
+      },
+    },
   );
 
   return {

--- a/src/apis/level.ts
+++ b/src/apis/level.ts
@@ -1,0 +1,31 @@
+import { useQuery } from 'react-query';
+import { User } from '@type';
+import { AxiosError, AxiosResponse } from 'axios';
+import { useSetRecoilState } from 'recoil';
+import { userArchives } from '@store/level';
+import useAxiosInstance from './instance';
+
+export const useFetchUserArchives = async () => {
+  const { authInstance } = useAxiosInstance();
+  const setUserArchives = useSetRecoilState(userArchives);
+  const { data, isSuccess, isError, isLoading } = useQuery<
+    AxiosResponse<User>,
+    AxiosError
+  >('userArchives', () => authInstance.get('/auth-user'), {
+    onSuccess: ({ data }) => {
+      if (data) {
+        setUserArchives({
+          commentsLength: data.comments.length,
+          postsLength: data.posts.length,
+        });
+      }
+    },
+  });
+
+  return {
+    userArchivesData: data,
+    isUserArchivesSuccess: isSuccess,
+    isUserArchivesError: isError,
+    isUserArchivesLoading: isLoading,
+  };
+};

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from 'react-query';
 import { Post } from '@type';
 import { AxiosError, AxiosResponse } from 'axios';
+import { useArchives } from '@hooks/useArchives';
 import useAxiosInstance from './instance';
 
 const CHANNEL_ID = '650be15e89b54040ee691c0c'; // todo : env 파일에 추가
@@ -67,18 +68,27 @@ interface CreatePostRequestBody {
 export const useFetchCreatePost = () => {
   const { authInstance } = useAxiosInstance();
   const path = `/posts/create`;
+  const { addPostArchive } = useArchives();
 
   const { mutate, data, isLoading, isSuccess, isError } = useMutation<
     AxiosResponse<Post>,
     AxiosError,
     CreatePostRequestBody
-  >('createPostMutation', (body: CreatePostRequestBody) => {
-    const formData = new FormData();
-    formData.append('title', body.title);
-    formData.append('image', '');
-    formData.append('channelId', CHANNEL_ID);
-    return authInstance.post(path, formData);
-  });
+  >(
+    'createPostMutation',
+    (body: CreatePostRequestBody) => {
+      const formData = new FormData();
+      formData.append('title', body.title);
+      formData.append('image', '');
+      formData.append('channelId', CHANNEL_ID);
+      return authInstance.post(path, formData);
+    },
+    {
+      onSuccess: () => {
+        addPostArchive();
+      },
+    },
+  );
   return {
     createPostMutate: mutate,
     createPostData: data?.data._id,
@@ -95,10 +105,16 @@ interface DeletePostRequestBody {
 export const useFetchDeletePost = () => {
   const { authInstance } = useAxiosInstance();
   const path = `/posts/delete`;
+  const { removePostArchive } = useArchives();
 
   const { mutate, isLoading, isSuccess, isError } = useMutation(
     'deletePostMutation',
     (body: DeletePostRequestBody) => authInstance.delete(path, { data: body }),
+    {
+      onSuccess: () => {
+        removePostArchive();
+      },
+    },
   );
   return {
     deletePostMutate: mutate,

--- a/src/apis/profile.ts
+++ b/src/apis/profile.ts
@@ -1,6 +1,8 @@
 import { useMutation } from 'react-query';
 import { User } from '@type';
 import { AxiosError, AxiosResponse } from 'axios';
+import { useRecoilState } from 'recoil';
+import { authInfoState } from '@store/auth';
 import useAxiosInstance from './instance';
 
 interface UpdateFullNameRequestBody {
@@ -9,12 +11,20 @@ interface UpdateFullNameRequestBody {
 
 export const useFetchUpdateFullName = () => {
   const { authInstance } = useAxiosInstance();
+  const [auth, setAuth] = useRecoilState(authInfoState);
   const { mutate, data, isLoading, isError, isSuccess } = useMutation<
     AxiosResponse<User>,
     AxiosError,
     UpdateFullNameRequestBody
-  >('updateFullNameMutation', (body: UpdateFullNameRequestBody) =>
-    authInstance.put('/settings/update-user', { ...body, username: '' }),
+  >(
+    'updateFullNameMutation',
+    (body: UpdateFullNameRequestBody) =>
+      authInstance.put('/settings/update-user', { ...body, username: '' }),
+    {
+      onSuccess: ({ data }) => {
+        auth && setAuth({ ...auth, userFullName: data.fullName });
+      },
+    },
   );
   return {
     updateFullNameMutate: mutate,

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -5,6 +5,7 @@ import {
   faHeart as faEmptyHeart,
 } from '@fortawesome/free-regular-svg-icons';
 import {
+  faArrowRight,
   faArrowUp,
   faBell,
   faCheck,
@@ -49,7 +50,8 @@ export type IconName =
   | 'eye'
   | 'eye_slash'
   | 'double_check'
-  | 'arrow_up';
+  | 'arrow_up'
+  | 'arrow_right';
 
 const iconMap = {
   alert: faBell,
@@ -73,6 +75,7 @@ const iconMap = {
   eye_slash: faEyeSlash,
   double_check: faCheckDouble,
   arrow_up: faArrowUp,
+  arrow_right: faArrowRight,
 };
 
 interface IconProps {

--- a/src/components/LevelViewer/components/LevelModal.tsx
+++ b/src/components/LevelViewer/components/LevelModal.tsx
@@ -1,6 +1,11 @@
 import { CSSProperties, useEffect } from 'react';
 import ReactCanvasConfetti from 'react-canvas-confetti';
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
+import Icon from '@components/Icon';
+import { authInfoState } from '@store/auth';
+import { getUserLevelInfo } from '@utils/calculateUserLevel';
+import { ANGOLA_STYLES } from '@styles/commonStyles';
 import { useConfetti } from '../hooks/useConfetti';
 
 interface LevelModalProps {
@@ -18,38 +23,107 @@ const LevelModal = ({ level, onClose: handleClose }: LevelModalProps) => {
     left: 0,
   };
 
-  const { fire, getInstance } = useConfetti();
+  const { makeConfetti, getConfetti } = useConfetti();
+  const { userColor, userEmoji } = getUserLevelInfo(level);
+  const { userEmoji: prevEmoji } = getUserLevelInfo(level - 1);
+  const auth = useRecoilValue(authInfoState);
+
   useEffect(() => {
-    fire();
+    makeConfetti();
   }, []);
 
   return (
-    <>
+    <Wrapper>
       <Container>
-        <div>레벨 상승 Lv.{level}</div>
-        <button onClick={handleClose}>X</button>
+        <LevelIcon>
+          {prevEmoji}
+          <Icon name="arrow_right" />
+          {userEmoji}
+        </LevelIcon>
+        <div>
+          축하합니다 <Name>{auth?.userFullName}</Name>님!
+        </div>
+        <div>
+          <Level
+            className={level === 7 ? 'full' : 'not_full'}
+            color={userColor}>
+            레벨 {level}
+          </Level>
+          에 도달했습니다
+        </div>
+        <Button
+          level={level}
+          onClick={handleClose}>
+          더 올리러 가기
+        </Button>
       </Container>
       <ReactCanvasConfetti
-        refConfetti={getInstance}
+        refConfetti={getConfetti}
         style={canvasStyles}
       />
-    </>
+    </Wrapper>
   );
 };
 
 export default LevelModal;
 
-const Container = styled.div`
+const Wrapper = styled.div`
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: auto;
-  width: 400px;
-  height: 200px;
-  font-size: 60px;
-  background-color: white;
-  color: black;
-  z-index: 100;
+  width: 100%;
+  height: 100%;
+  z-index: 15;
+  backdrop-filter: blur(2.5px);
+  background-color: rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Container = styled.div`
+  font-size: ${ANGOLA_STYLES.textSize.titleLg};
+  display: flex;
+  gap: 12px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: ${ANGOLA_STYLES.color.white};
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0px 4px 0px 0px ${ANGOLA_STYLES.color.gray};
+`;
+
+const LevelIcon = styled.div`
+  margin-bottom: 20px;
+`;
+
+const Name = styled.h1`
+  display: inline;
+`;
+
+const Level = styled.h1<{ color: string }>`
+  display: inline;
+  &.full {
+    background: ${({ color }) => color};
+    -webkit-text-fill-color: transparent;
+    -webkit-background-clip: text;
+  }
+  &.not_full {
+    color: ${({ color }) => color};
+  }
+`;
+
+const Button = styled.button<{ level: number }>`
+  background: ${({ level }) => ANGOLA_STYLES.color.levels[level].fill};
+  color: ${({ level }) => ANGOLA_STYLES.color.levels[level].text};
+  font-size: ${ANGOLA_STYLES.textSize.titleSm};
+  padding: 8px 12px;
+  margin-top: 20px;
+  border-radius: 24px;
+  border: none;
+  box-shadow: 0px 4px 0px 0px ${ANGOLA_STYLES.color.gray};
+  cursor: pointer;
+  translate: 0.2s;
+  &:hover:not(:active) {
+    transform: scale(1.02);
+  }
 `;

--- a/src/components/LevelViewer/components/LevelModal.tsx
+++ b/src/components/LevelViewer/components/LevelModal.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+interface LevelModalProps {
+  level: number;
+  onClose: VoidFunction;
+}
+
+const LevelModal = ({ level, onClose: handleClose }: LevelModalProps) => {
+  return (
+    <Container>
+      <div>레벨 상승 Lv.{level}</div>
+      <button onClick={handleClose}>X</button>
+    </Container>
+  );
+};
+
+export default LevelModal;
+
+const Container = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  width: 400px;
+  height: 200px;
+  font-size: 60px;
+  background-color: white;
+  color: black;
+  z-index: 100;
+`;

--- a/src/components/LevelViewer/components/LevelModal.tsx
+++ b/src/components/LevelViewer/components/LevelModal.tsx
@@ -1,4 +1,7 @@
+import { CSSProperties, useEffect } from 'react';
+import ReactCanvasConfetti from 'react-canvas-confetti';
 import styled from '@emotion/styled';
+import { useConfetti } from '../hooks/useConfetti';
 
 interface LevelModalProps {
   level: number;
@@ -6,11 +9,31 @@ interface LevelModalProps {
 }
 
 const LevelModal = ({ level, onClose: handleClose }: LevelModalProps) => {
+  const canvasStyles: CSSProperties = {
+    position: 'fixed',
+    pointerEvents: 'none',
+    width: '100%',
+    height: '100%',
+    top: 0,
+    left: 0,
+  };
+
+  const { fire, getInstance } = useConfetti();
+  useEffect(() => {
+    fire();
+  }, []);
+
   return (
-    <Container>
-      <div>레벨 상승 Lv.{level}</div>
-      <button onClick={handleClose}>X</button>
-    </Container>
+    <>
+      <Container>
+        <div>레벨 상승 Lv.{level}</div>
+        <button onClick={handleClose}>X</button>
+      </Container>
+      <ReactCanvasConfetti
+        refConfetti={getInstance}
+        style={canvasStyles}
+      />
+    </>
   );
 };
 

--- a/src/components/LevelViewer/hooks/useConfetti.tsx
+++ b/src/components/LevelViewer/hooks/useConfetti.tsx
@@ -4,7 +4,7 @@ import { CreateTypes, Options } from 'canvas-confetti';
 export const useConfetti = () => {
   const refAnimationInstance = useRef<CreateTypes | null>(null);
 
-  const getInstance = useCallback((instance: CreateTypes | null) => {
+  const getConfetti = useCallback((instance: CreateTypes | null) => {
     refAnimationInstance.current = instance;
   }, []);
 
@@ -17,7 +17,7 @@ export const useConfetti = () => {
       });
   }, []);
 
-  const fire = useCallback(() => {
+  const makeConfetti = useCallback(() => {
     makeShot(0.25, {
       spread: 26,
       startVelocity: 55,
@@ -46,5 +46,5 @@ export const useConfetti = () => {
     });
   }, [makeShot]);
 
-  return { getInstance, fire };
+  return { getConfetti, makeConfetti };
 };

--- a/src/components/LevelViewer/hooks/useConfetti.tsx
+++ b/src/components/LevelViewer/hooks/useConfetti.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useRef } from 'react';
+import { CreateTypes, Options } from 'canvas-confetti';
+
+export const useConfetti = () => {
+  const refAnimationInstance = useRef<CreateTypes | null>(null);
+
+  const getInstance = useCallback((instance: CreateTypes | null) => {
+    refAnimationInstance.current = instance;
+  }, []);
+
+  const makeShot = useCallback((particleRatio: number, opts: Options) => {
+    refAnimationInstance.current &&
+      refAnimationInstance.current({
+        ...opts,
+        origin: { y: 0.7 },
+        particleCount: Math.floor(200 * particleRatio),
+      });
+  }, []);
+
+  const fire = useCallback(() => {
+    makeShot(0.25, {
+      spread: 26,
+      startVelocity: 55,
+    });
+
+    makeShot(0.2, {
+      spread: 60,
+    });
+
+    makeShot(0.35, {
+      spread: 100,
+      decay: 0.91,
+      scalar: 0.8,
+    });
+
+    makeShot(0.1, {
+      spread: 120,
+      startVelocity: 25,
+      decay: 0.92,
+      scalar: 1.2,
+    });
+
+    makeShot(0.1, {
+      spread: 120,
+      startVelocity: 45,
+    });
+  }, [makeShot]);
+
+  return { getInstance, fire };
+};

--- a/src/components/LevelViewer/index.tsx
+++ b/src/components/LevelViewer/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useRecoilValue } from 'recoil';
+import { userArchives, userLevel } from '@store/level';
+import LevelModal from './components/LevelModal';
+import { checkIsNumber } from './utils/checkIsNumber';
+
+const LevelViewer = () => {
+  const archives = useRecoilValue(userArchives);
+  const level = useRecoilValue(userLevel);
+  const prevLevel = useRef(level);
+  const [isUpperLevel, setIsUpperLevel] = useState(false);
+
+  useEffect(() => {
+    if (level === prevLevel.current) return;
+    if (checkIsNumber(prevLevel.current) && checkIsNumber(level)) {
+      setIsUpperLevel(prevLevel.current < level);
+    }
+    prevLevel.current = level;
+  }, [archives, level]);
+
+  useEffect(() => {
+    isUpperLevel && console.log('레벨상승', level, '도달!');
+  }, [isUpperLevel]);
+
+  const appNode = document.getElementById('app');
+
+  return (
+    <>
+      {isUpperLevel &&
+        level &&
+        appNode &&
+        createPortal(
+          <LevelModal
+            level={level}
+            onClose={() => setIsUpperLevel(false)}
+          />,
+          appNode,
+        )}
+    </>
+  );
+};
+
+export default LevelViewer;

--- a/src/components/LevelViewer/utils/checkIsNumber.ts
+++ b/src/components/LevelViewer/utils/checkIsNumber.ts
@@ -1,0 +1,5 @@
+export const checkIsNumber = (
+  target: null | undefined | number,
+): target is number => {
+  return typeof target === 'number';
+};

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { redirects, routes } from '@routes';
 import Header from '@components/Header';
+import LevelViewer from '@components/LevelViewer';
 import { useFetchUserArchives } from '@apis/level';
 import useCurrentPage from '@hooks/useCurrentPage';
 import { useScrollToTop } from '@hooks/useScrollToTop';
@@ -30,6 +31,7 @@ const Main = () => {
 
   return (
     <MainContainer>
+      <LevelViewer />
       <Header
         title={title}
         sortProps={name === 'search' ? objectForSort : undefined}

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { redirects, routes } from '@routes';
 import Header from '@components/Header';
+import { useFetchUserArchives } from '@apis/level';
 import useCurrentPage from '@hooks/useCurrentPage';
 import { useScrollToTop } from '@hooks/useScrollToTop';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
@@ -12,6 +13,7 @@ const Main = () => {
   const { title, name, params, search } = useCurrentPage();
   const location = useLocation();
   const [scrollTargetRef, scrollToTop] = useScrollToTop<HTMLDivElement>();
+  useFetchUserArchives();
 
   useEffect(() => {
     scrollToTop();

--- a/src/hooks/useArchives.ts
+++ b/src/hooks/useArchives.ts
@@ -1,0 +1,33 @@
+import { useRecoilState } from 'recoil';
+import { userArchives } from '@store/level';
+
+export const useArchives = () => {
+  const [archives, setArchives] = useRecoilState(userArchives);
+
+  const addCommentArchive = () => {
+    if (!archives) return;
+    setArchives({ ...archives, commentsLength: archives.commentsLength + 1 });
+  };
+
+  const removeCommentArchive = () => {
+    if (!archives) return;
+    setArchives({ ...archives, commentsLength: archives.commentsLength - 1 });
+  };
+
+  const addPostArchive = () => {
+    if (!archives) return;
+    setArchives({ ...archives, postsLength: archives.postsLength + 1 });
+  };
+
+  const removePostArchive = () => {
+    if (!archives) return;
+    setArchives({ ...archives, postsLength: archives.postsLength - 1 });
+  };
+
+  return {
+    addCommentArchive,
+    removeCommentArchive,
+    addPostArchive,
+    removePostArchive,
+  };
+};

--- a/src/store/level.ts
+++ b/src/store/level.ts
@@ -1,0 +1,17 @@
+import { atom, selector } from 'recoil';
+import { calculateLevelByArchives } from '@utils/calculateUserLevel';
+import { Archives } from '@type/level';
+
+export const userArchives = atom<Archives | null>({
+  key: 'userArchives',
+  default: null,
+});
+
+export const userLevel = selector({
+  key: 'userLevel',
+  get: ({ get }) => {
+    const storedArchives = get(userArchives);
+    if (!storedArchives) return null;
+    return calculateLevelByArchives(storedArchives);
+  },
+});

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,5 @@
 export interface AuthInfo {
-	token: string;
-	userId: string;
+  userFullName: string;
+  token: string;
+  userId: string;
 }

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -1,0 +1,4 @@
+export interface Archives {
+  commentsLength: number;
+  postsLength: number;
+}

--- a/src/utils/calculateUserLevel.ts
+++ b/src/utils/calculateUserLevel.ts
@@ -1,13 +1,23 @@
 import { ANGOLA_STYLES } from '@styles/commonStyles';
-import { User } from '@type/index';
+import type { User } from '@type/index';
+import type { Archives } from '@type/level';
 
 const LEVEL_EMOJI = ['🌱', '🥚', '🐣', '🐥', '🐔', '🕊️', '🐉', '👑'];
 
-export const calculateLevel = (user: User): number => {
-  const score = user.comments.length + user.posts.length;
+const makeScoreToLevel = (score: number) => {
   if (score > 60) return 7;
   if (score <= 10) return Math.floor((score + 4) / 10);
   return Math.floor(score / 10) + 1;
+};
+
+export const calculateLevelByArchives = (archives: Archives) => {
+  const score = archives.commentsLength + archives.postsLength;
+  return makeScoreToLevel(score);
+};
+
+export const calculateLevel = (user: User): number => {
+  const score = user.posts.length + user.comments.length;
+  return makeScoreToLevel(score);
 };
 
 export const getUserLevelInfo = (level: number) => {


### PR DESCRIPTION
## 📑 구현 사항 

![앙 ~ 골라 (1)](https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/62418379/20d02637-4e98-4b1b-9b9c-fc6c69f1708a)

- [x] 레벨 저장 기능
  - 로그인할 때, 처음 로드 시 recoil 에 comment길이, post길이 저장되게 구현

- [x] 레벨 감지 기능
  - 포스트 작성/삭제, 댓글 작성/삭제 fetch 함수 내부에서 onSuccess 에서 recoil 저장 값 수정
  - **컴포넌트에서 호출 안해도 됨!**

- [x] 레벨업 모달 기능
  - 이전 레벨보다 레벨이 오르면 레벨업 알림창과 폭죽 보여줌
  - portal 로 구현

## 🚧 특이 사항

- auth 객체를 수정했습니다..! 레벨업 알림창에서 fullName 이 들어가면 좋을 것 같아서,
- auth 객체의 user 의 fullName 이 저장되게 했습니다
- 하지만.. 여러분의 로컬스토리지에는 fullName 이 없겠죠..!
- 따라서.. 이게 merge 되는 즉시 로컬스토리지를 clear 하시거나 로그아웃 해주세요 호호.....

</br>

## 🚨관련 이슈

#137