### PR TITLE
[Fix] - MyPage 1차 QA 결과 반영

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -5,7 +5,7 @@ import useAxiosInstance from './instance';
 
 export const useFetchUsers = () => {
   const { baseInstance } = useAxiosInstance();
-  const { data, isError, isSuccess, isLoading } = useQuery<
+  const { data, isError, isSuccess, isLoading, refetch } = useQuery<
     AxiosResponse<User[]>,
     AxiosError,
     User[]
@@ -19,6 +19,7 @@ export const useFetchUsers = () => {
     isUsersError: isError,
     isUsersSuccess: isSuccess,
     isUsersLoading: isLoading,
+    usersDataRefetch: refetch,
   };
 };
 

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -150,10 +150,10 @@ const MyInfo = ({
               type="button"
               onClick={handleClickDuplicatedFullNameCheckButton}
               style={{
-                width: '100px',
-                height: '48px',
+                width: '120px',
+                height: '40px',
                 padding: '0',
-                fontSize: ANGOLA_STYLES.textSize.titleSm,
+                fontSize: `${ANGOLA_STYLES.textSize.text}`,
               }}>
               {CHECK_DUPLICATE_BUTTON}
             </Button>
@@ -161,8 +161,8 @@ const MyInfo = ({
               onClick={handleClickUpdateFullName}
               size="sm"
               style={{
-                width: '48px',
-                height: '48px',
+                width: '45px',
+                height: '45px',
                 borderRadius: '50%',
                 padding: '0px',
               }}
@@ -187,10 +187,11 @@ const MyInfo = ({
               onClick={handleClickUpdateFullName}
               size="sm"
               style={{
-                width: '48px',
-                height: '48px',
+                width: '45px',
+                height: '45px',
                 borderRadius: '50%',
                 padding: '0px',
+                fontSize: `${ANGOLA_STYLES.textSize.text}`,
               }}>
               <Icon
                 name="edit"
@@ -279,8 +280,9 @@ const MyInfo = ({
             onClick={handleClickUpdatePassWord}
             disabled={handleAcceptPassWordButton()}
             style={{
-              width: '150px',
+              width: '120px',
               height: '40px',
+              fontSize: `${ANGOLA_STYLES.textSize.text}`,
             }}>
             {PASSWORD_BUTTON.DONE_MSG}
           </Button>
@@ -288,8 +290,9 @@ const MyInfo = ({
           <Button
             onClick={handleClickUpdatePassWord}
             style={{
-              width: '180px',
+              width: '150px',
               height: '40px',
+              fontSize: `${ANGOLA_STYLES.textSize.text}`,
             }}>
             {PASSWORD_BUTTON.EDIT_MSG}
           </Button>
@@ -304,8 +307,9 @@ const MyInfo = ({
             <Button
               onClick={handleClickLogOut}
               style={{
-                width: '150px',
+                width: '120px',
                 height: '40px',
+                fontSize: `${ANGOLA_STYLES.textSize.text}`,
               }}>
               {LOG_OUT_TEXT}
             </Button>

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -82,7 +82,6 @@ const MyInfo = ({
 
   return (
     <MyInfoWrapper>
-      {isUpdateProfileImageLoading && <Spinner />}
       <MyProfileContainer>
         <Emoji>{myEmoji}</Emoji>
         <EditProfile htmlFor="profile">
@@ -94,6 +93,7 @@ const MyInfo = ({
             }
             alt={USER_PROFILE_IMAGE.ALT}
           />
+          {isUpdateProfileImageLoading && <Spinner />}
         </EditProfile>
         <ProfileInput
           type="file"

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -277,11 +277,20 @@ const MyInfo = ({
         {isEditingPassWord ? (
           <Button
             onClick={handleClickUpdatePassWord}
-            disabled={handleAcceptPassWordButton()}>
+            disabled={handleAcceptPassWordButton()}
+            style={{
+              width: '150px',
+              height: '40px',
+            }}>
             {PASSWORD_BUTTON.DONE_MSG}
           </Button>
         ) : (
-          <Button onClick={handleClickUpdatePassWord}>
+          <Button
+            onClick={handleClickUpdatePassWord}
+            style={{
+              width: '180px',
+              height: '40px',
+            }}>
             {PASSWORD_BUTTON.EDIT_MSG}
           </Button>
         )}
@@ -292,7 +301,14 @@ const MyInfo = ({
         )}
         {isEditingPassWord ? null : (
           <>
-            <Button onClick={handleClickLogOut}>{LOG_OUT_TEXT}</Button>
+            <Button
+              onClick={handleClickLogOut}
+              style={{
+                width: '150px',
+                height: '40px',
+              }}>
+              {LOG_OUT_TEXT}
+            </Button>
             {isLogOutModalOpen && (
               <Modal onClose={() => setIsLogOutModalOpen(false)}>
                 {MODAL_ERROR_MESSAGE.LOG_OUT}

--- a/src/pages/MyPage/constants/index.ts
+++ b/src/pages/MyPage/constants/index.ts
@@ -26,3 +26,5 @@ export const MODAL_ERROR_MESSAGE = {
   PASSWORD: '비밀번호 변경 실패',
   LOG_OUT: '로그아웃 실패',
 };
+
+export const PASSWORD_CONFIRM_MESSAGE = '비밀번호 확인란을 입력하세요.';

--- a/src/pages/MyPage/hooks/useUpdateFullName.ts
+++ b/src/pages/MyPage/hooks/useUpdateFullName.ts
@@ -11,11 +11,14 @@ interface useUpdateFullNameProps {
 }
 
 const useUpdateFullName = ({ name }: useUpdateFullNameProps) => {
-  const { updateFullNameMutate, isUpdateFullNameError } =
-    useFetchUpdateFullName();
+  const {
+    updateFullNameMutate,
+    isUpdateFullNameError,
+    isUpdateFullNameSuccess,
+  } = useFetchUpdateFullName();
   const [newFullName, setNewFullName] = useState(name);
   const [isEditingFullName, setIsEditingFullName] = useState(false);
-  const { usersData } = useFetchUsers();
+  const { usersData, usersDataRefetch } = useFetchUsers();
   const [invalidFullNameMsg, setInvalidFullNameMsg] = useState('');
   const [validFullNameMsg, setValidFullNameMsg] = useState('');
   const [isDuplicatedFullNameChecked, setIsDuplicatedFullNameChecked] =
@@ -81,6 +84,12 @@ const useUpdateFullName = ({ name }: useUpdateFullNameProps) => {
       setNewFullName(name);
     }
   }, [isUpdateFullNameError, setNewFullName, name]);
+
+  useEffect(() => {
+    if (isUpdateFullNameSuccess) {
+      usersDataRefetch();
+    }
+  }, [isUpdateFullNameSuccess, usersDataRefetch]);
 
   return {
     newFullName,

--- a/src/pages/MyPage/hooks/useUpdatePassWord.ts
+++ b/src/pages/MyPage/hooks/useUpdatePassWord.ts
@@ -2,6 +2,7 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import { useFetchUpdatePassword } from '@apis/profile';
 import { checkPassWordPattern } from '@utils/userAuthentication';
 import { CHECK_MSG } from '@constants/index';
+import { PASSWORD_CONFIRM_MESSAGE } from '../constants';
 
 const useUpdatePassWord = () => {
   const { updatePasswordMutate, updatePasswordData, isUpdatePasswordError } =
@@ -70,10 +71,13 @@ const useUpdatePassWord = () => {
         confirmNewPassWord: e.target.value,
       },
     );
+
     setConfirmNewPassWord(e.target.value);
     setValidPasswordConfirmMsg('');
 
-    if (!isValidPasswordConfirm) {
+    if (!e.target.value) {
+      setInvalidPasswordConfirmMsg(`${PASSWORD_CONFIRM_MESSAGE}`);
+    } else if (!isValidPasswordConfirm) {
       setInvalidPasswordConfirmMsg(passwordConfirmMsg);
     } else {
       setValidPasswordConfirmMsg(passwordConfirmMsg);

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -18,6 +18,11 @@ const MyPage = () => {
   const auth = useRecoilValue(authInfoState);
   const { name } = useCurrentPage();
   const navigate = useNavigate();
+
+  if (!auth?.userId) {
+    navigate('/login', { replace: true });
+  }
+
   const { userData, isUserLoading, userDataRefetch } = useFetchUser(
     auth?.userId as string,
   );
@@ -32,10 +37,6 @@ const MyPage = () => {
       userDataRefetch();
     }
   }, [isDeletePostSuccess, userDataRefetch]);
-
-  if (!auth?.userId) {
-    navigate('/login', { replace: true });
-  }
 
   if (isUserLoading) {
     return <Spinner />;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { calculateLevel, getUserLevelInfo } from '@utils';
 import { useRecoilValue } from 'recoil';
@@ -16,6 +17,7 @@ import { MY_PAGE } from './constants';
 const MyPage = () => {
   const auth = useRecoilValue(authInfoState);
   const { name } = useCurrentPage();
+  const navigate = useNavigate();
   const { userData, isUserLoading, userDataRefetch } = useFetchUser(
     auth?.userId as string,
   );
@@ -30,6 +32,10 @@ const MyPage = () => {
       userDataRefetch();
     }
   }, [isDeletePostSuccess, userDataRefetch]);
+
+  if (!auth?.userId) {
+    navigate('/login', { replace: true });
+  }
 
   if (isUserLoading) {
     return <Spinner />;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -18,8 +18,12 @@ const MyPage = () => {
   const { name } = useCurrentPage();
   const { userData, isUserLoading, userDataRefetch } = useFetchUser(
     auth?.userId as string,
-  ); // TODO: refetch 할 때마다 데이터 로딩 처리하기
+  );
   const { deletePostMutate, isDeletePostSuccess } = useFetchDeletePost();
+
+  const isSameId = () => {
+    return userData?._id === auth?.userId;
+  };
 
   useEffect(() => {
     if (isDeletePostSuccess) {
@@ -30,43 +34,50 @@ const MyPage = () => {
   if (isUserLoading) {
     return <Spinner />;
   }
+
   return (
     <MyPageWrapper>
-      {userData && (
-        <MyInfo
-          id={userData._id}
-          image={userData.image}
-          name={userData.fullName}
-          likes={userData.posts.reduce(
-            (likes, post) => likes + post.likes.length,
-            0,
-          )}
-          followers={userData.followers?.length}
-          following={userData.following?.length}
-          myLevel={calculateLevel(userData)}
-          myColor={getUserLevelInfo(calculateLevel(userData)).userColor}
-          myEmoji={getUserLevelInfo(calculateLevel(userData)).userEmoji}
-        />
-      )}
-      <PostsListContainer>
-        <PostsListTitle>
-          {userData?.posts.length === 0
-            ? USER_POSTS_TITLE.NO_POSTS
-            : USER_POSTS_TITLE.POSTS}
-        </PostsListTitle>
-        <PostsListUl>
-          {userData?.posts?.map((post) => (
-            <PostListItem
-              key={post._id}
-              id={post._id}
-              title={post.title}
+      {isSameId() ? (
+        <>
+          {userData && (
+            <MyInfo
+              id={userData._id}
               image={userData.image}
-              canDeletePost={name === MY_PAGE}
-              deletePostMutate={deletePostMutate}
+              name={userData.fullName}
+              likes={userData.posts.reduce(
+                (likes, post) => likes + post.likes.length,
+                0,
+              )}
+              followers={userData.followers?.length}
+              following={userData.following?.length}
+              myLevel={calculateLevel(userData)}
+              myColor={getUserLevelInfo(calculateLevel(userData)).userColor}
+              myEmoji={getUserLevelInfo(calculateLevel(userData)).userEmoji}
             />
-          ))}
-        </PostsListUl>
-      </PostsListContainer>
+          )}
+          <PostsListContainer>
+            <PostsListTitle>
+              {userData?.posts.length === 0
+                ? USER_POSTS_TITLE.NO_POSTS
+                : USER_POSTS_TITLE.POSTS}
+            </PostsListTitle>
+            <PostsListUl>
+              {userData?.posts?.map((post) => (
+                <PostListItem
+                  key={post._id}
+                  id={post._id}
+                  title={post.title}
+                  image={userData.image}
+                  canDeletePost={name === MY_PAGE}
+                  deletePostMutate={deletePostMutate}
+                />
+              ))}
+            </PostsListUl>
+          </PostsListContainer>
+        </>
+      ) : (
+        <Spinner />
+      )}
     </MyPageWrapper>
   );
 };

--- a/src/pages/UserPage/UserInfo.tsx
+++ b/src/pages/UserPage/UserInfo.tsx
@@ -91,7 +91,13 @@ const UserInfo = ({
             toggle={isFollowed}
             size="md"
             onClick={handleClickFollowButton}
-            disabled={disabledFollowButton()}>
+            disabled={disabledFollowButton()}
+            style={{
+              width: '120px',
+              height: '40px',
+              padding: '0',
+              fontSize: `${ANGOLA_STYLES.textSize.text}`,
+            }}>
             {isFollowed
               ? `${FOLLOW_MESSAGE.UN_FOLLOW}`
               : `${FOLLOW_MESSAGE.FOLLOW}`}

--- a/src/utils/userAuthentication.ts
+++ b/src/utils/userAuthentication.ts
@@ -1,13 +1,10 @@
 import { User } from '@type';
 
-const NUMBER = /[0-9]/;
-const CHARACTER = /[a-zA-Z]/;
-const SPECIAL_CHARACTER = /[~!@#$%^&*()_+|<>?:{}]/;
+const PASSWORD_REGEXP = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{5,15}$/;
 const EMAIL_REGEXP = /[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/;
-const FULLNAME_MIN_LENGTH = 3;
-const FULLNAME_MAX_LENGTH = 8;
-const PASSWORD_MIN_LENGTH = 5;
-const PASSWORD_MAX_LENGTH = 15;
+const SPECIAL_CHARACTER_REGEXP = /[~!@#$%^&*()_+|<>?:{}]/;
+const FULL_NAME_MIN_LENGTH = 3;
+const FULL_NAME_MAX_LENGTH = 8;
 
 interface checkEmailPatternProps {
   email: string;
@@ -57,9 +54,9 @@ export const checkFullNamePattern = ({
   let msg;
 
   if (
-    SPECIAL_CHARACTER.test(trimmedFullName) ||
-    trimmedFullName.length > FULLNAME_MAX_LENGTH ||
-    trimmedFullName.length < FULLNAME_MIN_LENGTH
+    SPECIAL_CHARACTER_REGEXP.test(trimmedFullName) ||
+    trimmedFullName.length < FULL_NAME_MIN_LENGTH ||
+    trimmedFullName.length > FULL_NAME_MAX_LENGTH
   ) {
     msg = '닉네임은 3자리 이상 8자리 이하 문자 또는 숫자로 구성하여야 합니다.';
     isValidFullName = false;
@@ -81,20 +78,16 @@ export const checkPassWordPattern = ({
   confirmNewPassWord,
 }: checkPassWordPatternProps) => {
   const trimmedPassWord = newPassWord.trim();
+
   let isValidPassword = false;
   let isValidPasswordConfirm = false;
   let passwordMsg = '';
   let passwordConfirmMsg = '';
+  console.log(trimmedPassWord.length);
 
-  if (
-    !NUMBER.test(trimmedPassWord) ||
-    !CHARACTER.test(trimmedPassWord) ||
-    !SPECIAL_CHARACTER.test(trimmedPassWord) ||
-    trimmedPassWord.length <= PASSWORD_MIN_LENGTH ||
-    trimmedPassWord.length >= PASSWORD_MAX_LENGTH
-  ) {
+  if (!PASSWORD_REGEXP.test(trimmedPassWord)) {
     passwordMsg =
-      '비밀번호는 5자리 이상 15자 이하 문자, 숫자, 특수문자로 구성하여야 합니다.';
+      '비밀번호는 5자리 이상 15자 이하 문자, 숫자, 특수문자를 모두 포함해야 합니다.';
     isValidPassword = false;
   } else {
     isValidPassword = true;

--- a/src/utils/userAuthentication.ts
+++ b/src/utils/userAuthentication.ts
@@ -103,6 +103,9 @@ export const checkPassWordPattern = ({
   if (newPassWord !== confirmNewPassWord) {
     passwordConfirmMsg = '비밀번호가 일치하지 않습니다.';
     isValidPasswordConfirm = false;
+  } else if (newPassWord === '' && confirmNewPassWord === '') {
+    passwordConfirmMsg = '비밀번호를 입력해주세요';
+    isValidPasswordConfirm = false;
   } else {
     passwordConfirmMsg = '비밀번호가 일치합니다.';
     isValidPasswordConfirm = true;


### PR DESCRIPTION
## 📑 구현 사항 

- [x] 비밀번호 변경 시, 확인란에 아무것도 입력 안 했을 때도 일치합니다 문구 나오는 현상 수정 81efbaa0d9f6dc0ee5801e8add70e0d9653334d1
<img width="820" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/109654823/70f51aeb-2fcc-4826-b878-808651511a90">

- [x] 비밀번호 변경하기, 로그아웃 버튼 hover시 border 크기가 커져 옆에 글자들이 밀리는 현상 수정 951310def136db6503ed537815291227e23d1527
- [x] 이미지를 변경할 때 로딩 아이콘이 프로필 이미지에 가려지는 현상 수정 7e92b62bb27283230170422bd8320932648aaeeb
<img width="817" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/109654823/547b8af2-939e-4688-8ab0-14eb28a301fa">

- [x] 변경 전 닉네임으로 다시 변경하려고 중복확인을 할 시 이미 가입된 닉네임이라고 보여지는 현상 수정 02a83f306d0af651880ffb5ff9848180da5a5fc4

https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/109654823/232e4c34-be82-408e-b597-76ab1536ccce


- [x] 비밀번호 특수 문자 정규식 변경, 비밀번호 변경 시 5글자, 15글자 통과 안되는 현상 수정 (비밀번호는 5~15글자 사이의 영문+숫자+특수문자를 모두 포함해야 함) ee6b683867a38a66e56557e93221b23633158986
- [x] 유저 페이지를 들어갔다가 마이 페이지를 들어가면 전에 있던 데이터가 잠깐 보이는 현상 수정 28d567fc4422eecb4dfaacd12639d15559f4ca26
- [x] 로그인하지 않고 url로 직접 마이 페이지로 이동되는 현상 수정 -> 로그인 페이지로 redirect (추후에 세진님이 만들어주신 훅으로 교체) 13a0efe439ff5565e2f2130faae3a73fddd64ead


## 🚧 특이 사항

- [ ] 브라우저 width 감소 시, 포스트 목록 중 제목 창 세로로 길어짐 (포스트 리스트에서 처리)
- [ ] 작성한 포스트목록 중 제목이 긴 포스트의 제목 창의 UI가 긴 현상 (포스트 리스트에서 처리)


## 🚨관련 이슈

#173 