### PR TITLE
[Fix] - 검색 페이지 1차 QA 결과 반영

### DIFF
--- a/src/apis/search.ts
+++ b/src/apis/search.ts
@@ -11,13 +11,18 @@ export const useFetchSearchPosts = ({ query }: SearchRequestQuery) => {
   const { baseInstance } = useAxiosInstance();
   const { data, isSuccess, isError, isLoading, refetch } = useQuery<
     AxiosResponse<(User | Post)[]>,
-    AxiosError
-  >('searchPosts', () => baseInstance.get(`/search/all/${query}`));
+    AxiosError,
+    Post[]
+  >('searchPosts', () => baseInstance.get(`/search/all/${query}`), {
+    select: ({ data }) => {
+      return data.filter((resData) => {
+        return 'title' in resData;
+      }) as Post[];
+    },
+  });
 
   return {
-    searchPostsData: data?.data.filter((resData) => {
-      return 'title' in resData;
-    }) as Post[],
+    searchPostsData: data,
     isSearchPostsSuccess: isSuccess,
     isSearchPostsError: isError,
     isSearchPostsLoading: isLoading,

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -23,7 +23,6 @@ const PostList = ({ keyword, sort }: PostListProps) => {
             <PostListItem
               key={post._id}
               id={post._id}
-              image={post.author.image}
               title={post.title}
               likes={post.likes.length}
               comments={post.comments.length}

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { NON_SEARCH_TEXT } from '@pages/SearchPage/constants';
 import { usePostSort } from '@pages/SearchPage/hooks';
 import PostListItem from '@components/PostListItem';
 import Spinner from '@components/Spinner';
@@ -17,16 +18,20 @@ const PostList = ({ keyword, sort }: PostListProps) => {
   return (
     <>
       <PostListItems>
-        {resultData?.map((post) => (
-          <PostListItem
-            key={post._id}
-            id={post._id}
-            image={post.author.image}
-            title={post.title}
-            likes={post.likes.length}
-            comments={post.comments.length}
-          />
-        ))}
+        {resultData?.length !== 0 ? (
+          resultData?.map((post) => (
+            <PostListItem
+              key={post._id}
+              id={post._id}
+              image={post.author.image}
+              title={post.title}
+              likes={post.likes.length}
+              comments={post.comments.length}
+            />
+          ))
+        ) : (
+          <div>{NON_SEARCH_TEXT}</div>
+        )}
       </PostListItems>
       {(isAllPostsLoading || isSearchPostsLoading) && <Spinner />}
     </>

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -1,18 +1,16 @@
 import styled from '@emotion/styled';
 import { MORE_LINK_BUTTON_STYLES } from '@styles';
 import Icon from '@components/Icon';
-import Image from '@components/Image';
 import LinkButton from '@components/LinkButton';
 import Modal from '@components/Modal';
 import { splitPostBySeparator } from '@utils/parseDataBySeparator';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
-import { BUTTON_VALUES, USER_PROFILE_IMAGE } from '@constants/index';
+import { BUTTON_VALUES } from '@constants/index';
 import { DELETE_POST_MODAL } from './constants';
 import { useDeletePost } from './hooks';
 
 interface PostListItemProps {
   id: string;
-  image?: string;
   title: string;
   likes?: number;
   comments?: number;
@@ -22,7 +20,6 @@ interface PostListItemProps {
 
 const PostListItem = ({
   id,
-  image,
   title,
   likes,
   comments,
@@ -37,13 +34,6 @@ const PostListItem = ({
 
   return (
     <ListItemContainer>
-      <ImageContainer>
-        <Image
-          src={image ? image : USER_PROFILE_IMAGE.DEFAULT_SRC}
-          alt="프로필"
-          size={60}
-        />
-      </ImageContainer>
       <TitleContainer>
         <Title>{postTitle}</Title>
       </TitleContainer>
@@ -100,17 +90,6 @@ const ListItemContainer = styled.li`
   }
 `;
 
-const ImageContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0 0 0 16px;
-
-  @media (max-width: 800px) {
-    display: none;
-  }
-`;
-
 const TitleContainer = styled.div`
   display: flex;
   padding: 16px 32px;
@@ -120,10 +99,8 @@ const TitleContainer = styled.div`
   border-radius: 24px;
   background: #e5e5e5;
   overflow: hidden;
+  margin-left: 16px;
 
-  @media (max-width: 800px) {
-    margin-left: 20px;
-  }
   @media (max-width: 600px) {
     padding: 16px;
   }

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -115,7 +115,7 @@ const Title = styled.div`
   padding: 2px 0;
 
   @media (max-width: 600px) {
-    font-size: 16px;
+    font-size: ${ANGOLA_STYLES.textSize.text};
   }
 `;
 

--- a/src/components/PostListItem/index.tsx
+++ b/src/components/PostListItem/index.tsx
@@ -37,12 +37,13 @@ const PostListItem = ({
 
   return (
     <ListItemContainer>
-      <Image
-        src={image ? image : USER_PROFILE_IMAGE.DEFAULT_SRC}
-        alt="프로필"
-        size={60}
-        style={{ margin: '0 20px' }}
-      />
+      <ImageContainer>
+        <Image
+          src={image ? image : USER_PROFILE_IMAGE.DEFAULT_SRC}
+          alt="프로필"
+          size={60}
+        />
+      </ImageContainer>
       <TitleContainer>
         <Title>{postTitle}</Title>
       </TitleContainer>
@@ -85,6 +86,7 @@ export default PostListItem;
 const ListItemContainer = styled.li`
   display: flex;
   height: 100px;
+  justify-content: center;
   align-items: center;
   gap: 16px;
   width: 100%;
@@ -92,9 +94,20 @@ const ListItemContainer = styled.li`
   border: ${ANGOLA_STYLES.border.default};
   background: ${ANGOLA_STYLES.color.white};
   box-shadow: ${ANGOLA_STYLES.shadow.button.default};
-  overflow: hidden;
+
   &:has(.more:hover) {
     box-shadow: ${ANGOLA_STYLES.shadow.button.hover};
+  }
+`;
+
+const ImageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 0 0 16px;
+
+  @media (max-width: 800px) {
+    display: none;
   }
 `;
 
@@ -106,11 +119,27 @@ const TitleContainer = styled.div`
   flex-grow: 1;
   border-radius: 24px;
   background: #e5e5e5;
+  overflow: hidden;
+
+  @media (max-width: 800px) {
+    margin-left: 20px;
+  }
+  @media (max-width: 600px) {
+    padding: 16px;
+  }
 `;
 
 const Title = styled.div`
   color: ${ANGOLA_STYLES.color.text};
   font-size: ${ANGOLA_STYLES.textSize.titleSm};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 2px 0;
+
+  @media (max-width: 600px) {
+    font-size: 16px;
+  }
 `;
 
 const LikesAndComments = styled.div`
@@ -118,6 +147,11 @@ const LikesAndComments = styled.div`
   flex-direction: column;
   gap: 12px;
   font-size: ${ANGOLA_STYLES.textSize.title};
+  flex-shrink: 0;
+
+  @media (max-width: 800px) {
+    display: none;
+  }
 `;
 
 const DeleteButton = styled.div`
@@ -134,6 +168,7 @@ const DeleteButton = styled.div`
   &:hover {
     box-shadow: ${ANGOLA_STYLES.shadow.buttonSm.hover};
   }
+  flex-shrink: 0;
 `;
 
 const More = styled.div`
@@ -144,4 +179,13 @@ const More = styled.div`
   border-left: ${ANGOLA_STYLES.border.default};
   font-size: ${ANGOLA_STYLES.textSize.title};
   cursor: pointer;
+  flex-shrink: 0;
+
+  @media (max-width: 800px) {
+    width: 80px;
+  }
+
+  @media (max-width: 600px) {
+    width: 60px;
+  }
 `;

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { calculateLevel, getUserLevelInfo } from '@utils';
+import { NON_SEARCH_TEXT } from '@pages/SearchPage/constants';
 import { useUsersort } from '@pages/SearchPage/hooks';
 import Spinner from '@components/Spinner';
 import UserListItem from '@components/UserListItem';
@@ -18,17 +19,21 @@ const UserList = ({ keyword, sort }: UserListProps) => {
   return (
     <>
       <UserListItems>
-        {resultData?.map((user) => (
-          <UserListItem
-            key={user._id}
-            id={user._id}
-            image={user.image}
-            name={user.fullName}
-            level={calculateLevel(user)}
-            followers={user.followers.length}
-            userEmoji={getUserLevelInfo(calculateLevel(user)).userEmoji}
-          />
-        ))}
+        {resultData?.length !== 0 ? (
+          resultData?.map((user) => (
+            <UserListItem
+              key={user._id}
+              id={user._id}
+              image={user.image}
+              name={user.fullName}
+              level={calculateLevel(user)}
+              followers={user.followers.length}
+              userEmoji={getUserLevelInfo(calculateLevel(user)).userEmoji}
+            />
+          ))
+        ) : (
+          <div>{NON_SEARCH_TEXT}</div>
+        )}
       </UserListItems>
       {(isUsersLoading || isSearchUsersLoading) && <Spinner />}
     </>

--- a/src/components/UserListItem/index.tsx
+++ b/src/components/UserListItem/index.tsx
@@ -26,12 +26,13 @@ const UserListItem = ({
 }: UserListItemProps) => {
   return (
     <ListItemContainer>
-      <Image
-        src={image ? image : USER_PROFILE_IMAGE.DEFAULT_SRC}
-        alt="프로필"
-        size={60}
-        style={{ margin: '0 20px' }}
-      />
+      <ImageContainer>
+        <Image
+          src={image ? image : USER_PROFILE_IMAGE.DEFAULT_SRC}
+          alt="프로필"
+          size={60}
+        />
+      </ImageContainer>
 
       <UserInfo>
         <div className="user_name">
@@ -83,6 +84,17 @@ const ListItemContainer = styled.li`
   }
 `;
 
+const ImageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 0 0 16px;
+
+  @media (max-width: 600px) {
+    margin: 0 0 0 10px;
+  }
+`;
+
 const UserInfo = styled.div`
   display: flex;
   padding: 12px 0px;
@@ -96,6 +108,10 @@ const LevelAndFollowers = styled.div`
   flex-direction: column;
   gap: 12px;
   font-size: ${ANGOLA_STYLES.textSize.title};
+
+  @media (max-width: 800px) {
+    display: none;
+  }
 `;
 
 const More = styled.div`
@@ -106,4 +122,12 @@ const More = styled.div`
   border-left: ${ANGOLA_STYLES.border.default};
   font-size: ${ANGOLA_STYLES.textSize.title};
   cursor: pointer;
+
+  @media (max-width: 800px) {
+    width: 80px;
+  }
+
+  @media (max-width: 640px) {
+    display: none;
+  }
 `;

--- a/src/pages/SearchPage/constants/index.ts
+++ b/src/pages/SearchPage/constants/index.ts
@@ -1,0 +1,1 @@
+export const NON_SEARCH_TEXT = '검색 결과가 없습니다.';

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -31,4 +31,5 @@ export default SearchPage;
 
 const Container = styled.div`
   width: 100%;
+  padding-bottom: 32px;
 `;

--- a/src/pages/UserPage/index.tsx
+++ b/src/pages/UserPage/index.tsx
@@ -70,6 +70,8 @@ const UserPage = ({ userId = '' }: UserPageProps) => {
                   id={post._id}
                   image={userData.image}
                   title={post.title}
+                  likes={post.likes.length}
+                  comments={post.comments.length}
                 />
               ))}
             </PostsListUl>


### PR DESCRIPTION
## 📑 구현 사항 
 - [x] 리스트 반응형 스타일 적용
 - [x] keyword 검색 결과가 없을 때 문구 처리 추가
 - [x] 키워드 검색 시 포스트 리스트에 유저의 프로필이 기본으로 보이는 현상 수정
 - [x] 유저 페이지에서 작성한 포스트 리스트에 좋아요, 댓글 개수 보이도록 수정
 - [x] 아래 마진 추가

<br/>

## 🚧 특이 사항
포스트 검색 시 반환되는 데이터의 author가 User 객체가 아닌 user의 id라서 image가 존재하지 않습니다.
이미지를 적용하려면 PostListItem에서 해당 user id의 api를 호출해서 가져오면 되긴 하지만 이렇게 하면 item 하나당 api를 호출하게 되어
호출 빈도가 상당할 것이라고 생각되어 PostListItem에서는 프로필 이미지를 제거하였습니다.

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Angola_NaYoung/assets/39931980/f806ed1f-380b-458d-a2a8-748aa269821f)


</br>

## 🚨관련 이슈

#178 