### PR TITLE
[Fix] - SignUpPage 1차 QA 결과 반영

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -5,7 +5,7 @@ import useAxiosInstance from './instance';
 
 export const useFetchUsers = () => {
   const { baseInstance } = useAxiosInstance();
-  const { data, isError, isSuccess, isLoading } = useQuery<
+  const { data, isError, isSuccess, isLoading, refetch } = useQuery<
     AxiosResponse<User[]>,
     AxiosError,
     User[]
@@ -19,6 +19,7 @@ export const useFetchUsers = () => {
     isUsersError: isError,
     isUsersSuccess: isSuccess,
     isUsersLoading: isLoading,
+    usersDataRefetch: refetch,
   };
 };
 

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -150,10 +150,10 @@ const MyInfo = ({
               type="button"
               onClick={handleClickDuplicatedFullNameCheckButton}
               style={{
-                width: '100px',
-                height: '48px',
+                width: '120px',
+                height: '40px',
                 padding: '0',
-                fontSize: ANGOLA_STYLES.textSize.titleSm,
+                fontSize: `${ANGOLA_STYLES.textSize.text}`,
               }}>
               {CHECK_DUPLICATE_BUTTON}
             </Button>
@@ -161,8 +161,8 @@ const MyInfo = ({
               onClick={handleClickUpdateFullName}
               size="sm"
               style={{
-                width: '48px',
-                height: '48px',
+                width: '45px',
+                height: '45px',
                 borderRadius: '50%',
                 padding: '0px',
               }}
@@ -187,10 +187,11 @@ const MyInfo = ({
               onClick={handleClickUpdateFullName}
               size="sm"
               style={{
-                width: '48px',
-                height: '48px',
+                width: '45px',
+                height: '45px',
                 borderRadius: '50%',
                 padding: '0px',
+                fontSize: `${ANGOLA_STYLES.textSize.text}`,
               }}>
               <Icon
                 name="edit"
@@ -279,8 +280,9 @@ const MyInfo = ({
             onClick={handleClickUpdatePassWord}
             disabled={handleAcceptPassWordButton()}
             style={{
-              width: '150px',
+              width: '120px',
               height: '40px',
+              fontSize: `${ANGOLA_STYLES.textSize.text}`,
             }}>
             {PASSWORD_BUTTON.DONE_MSG}
           </Button>
@@ -288,8 +290,9 @@ const MyInfo = ({
           <Button
             onClick={handleClickUpdatePassWord}
             style={{
-              width: '180px',
+              width: '150px',
               height: '40px',
+              fontSize: `${ANGOLA_STYLES.textSize.text}`,
             }}>
             {PASSWORD_BUTTON.EDIT_MSG}
           </Button>
@@ -304,8 +307,9 @@ const MyInfo = ({
             <Button
               onClick={handleClickLogOut}
               style={{
-                width: '150px',
+                width: '120px',
                 height: '40px',
+                fontSize: `${ANGOLA_STYLES.textSize.text}`,
               }}>
               {LOG_OUT_TEXT}
             </Button>

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -82,7 +82,6 @@ const MyInfo = ({
 
   return (
     <MyInfoWrapper>
-      {isUpdateProfileImageLoading && <Spinner />}
       <MyProfileContainer>
         <Emoji>{myEmoji}</Emoji>
         <EditProfile htmlFor="profile">
@@ -94,6 +93,7 @@ const MyInfo = ({
             }
             alt={USER_PROFILE_IMAGE.ALT}
           />
+          {isUpdateProfileImageLoading && <Spinner />}
         </EditProfile>
         <ProfileInput
           type="file"

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -277,11 +277,20 @@ const MyInfo = ({
         {isEditingPassWord ? (
           <Button
             onClick={handleClickUpdatePassWord}
-            disabled={handleAcceptPassWordButton()}>
+            disabled={handleAcceptPassWordButton()}
+            style={{
+              width: '150px',
+              height: '40px',
+            }}>
             {PASSWORD_BUTTON.DONE_MSG}
           </Button>
         ) : (
-          <Button onClick={handleClickUpdatePassWord}>
+          <Button
+            onClick={handleClickUpdatePassWord}
+            style={{
+              width: '180px',
+              height: '40px',
+            }}>
             {PASSWORD_BUTTON.EDIT_MSG}
           </Button>
         )}
@@ -292,7 +301,14 @@ const MyInfo = ({
         )}
         {isEditingPassWord ? null : (
           <>
-            <Button onClick={handleClickLogOut}>{LOG_OUT_TEXT}</Button>
+            <Button
+              onClick={handleClickLogOut}
+              style={{
+                width: '150px',
+                height: '40px',
+              }}>
+              {LOG_OUT_TEXT}
+            </Button>
             {isLogOutModalOpen && (
               <Modal onClose={() => setIsLogOutModalOpen(false)}>
                 {MODAL_ERROR_MESSAGE.LOG_OUT}

--- a/src/pages/MyPage/constants/index.ts
+++ b/src/pages/MyPage/constants/index.ts
@@ -26,3 +26,5 @@ export const MODAL_ERROR_MESSAGE = {
   PASSWORD: '비밀번호 변경 실패',
   LOG_OUT: '로그아웃 실패',
 };
+
+export const PASSWORD_CONFIRM_MESSAGE = '비밀번호 확인란을 입력하세요.';

--- a/src/pages/MyPage/hooks/useUpdateFullName.ts
+++ b/src/pages/MyPage/hooks/useUpdateFullName.ts
@@ -11,11 +11,14 @@ interface useUpdateFullNameProps {
 }
 
 const useUpdateFullName = ({ name }: useUpdateFullNameProps) => {
-  const { updateFullNameMutate, isUpdateFullNameError } =
-    useFetchUpdateFullName();
+  const {
+    updateFullNameMutate,
+    isUpdateFullNameError,
+    isUpdateFullNameSuccess,
+  } = useFetchUpdateFullName();
   const [newFullName, setNewFullName] = useState(name);
   const [isEditingFullName, setIsEditingFullName] = useState(false);
-  const { usersData } = useFetchUsers();
+  const { usersData, usersDataRefetch } = useFetchUsers();
   const [invalidFullNameMsg, setInvalidFullNameMsg] = useState('');
   const [validFullNameMsg, setValidFullNameMsg] = useState('');
   const [isDuplicatedFullNameChecked, setIsDuplicatedFullNameChecked] =
@@ -81,6 +84,12 @@ const useUpdateFullName = ({ name }: useUpdateFullNameProps) => {
       setNewFullName(name);
     }
   }, [isUpdateFullNameError, setNewFullName, name]);
+
+  useEffect(() => {
+    if (isUpdateFullNameSuccess) {
+      usersDataRefetch();
+    }
+  }, [isUpdateFullNameSuccess, usersDataRefetch]);
 
   return {
     newFullName,

--- a/src/pages/MyPage/hooks/useUpdatePassWord.ts
+++ b/src/pages/MyPage/hooks/useUpdatePassWord.ts
@@ -2,6 +2,7 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import { useFetchUpdatePassword } from '@apis/profile';
 import { checkPassWordPattern } from '@utils/userAuthentication';
 import { CHECK_MSG } from '@constants/index';
+import { PASSWORD_CONFIRM_MESSAGE } from '../constants';
 
 const useUpdatePassWord = () => {
   const { updatePasswordMutate, updatePasswordData, isUpdatePasswordError } =
@@ -70,10 +71,13 @@ const useUpdatePassWord = () => {
         confirmNewPassWord: e.target.value,
       },
     );
+
     setConfirmNewPassWord(e.target.value);
     setValidPasswordConfirmMsg('');
 
-    if (!isValidPasswordConfirm) {
+    if (!e.target.value) {
+      setInvalidPasswordConfirmMsg(`${PASSWORD_CONFIRM_MESSAGE}`);
+    } else if (!isValidPasswordConfirm) {
       setInvalidPasswordConfirmMsg(passwordConfirmMsg);
     } else {
       setValidPasswordConfirmMsg(passwordConfirmMsg);

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { calculateLevel, getUserLevelInfo } from '@utils';
 import { useRecoilValue } from 'recoil';
@@ -16,6 +17,7 @@ import { MY_PAGE } from './constants';
 const MyPage = () => {
   const auth = useRecoilValue(authInfoState);
   const { name } = useCurrentPage();
+  const navigate = useNavigate();
   const { userData, isUserLoading, userDataRefetch } = useFetchUser(
     auth?.userId as string,
   );
@@ -30,6 +32,10 @@ const MyPage = () => {
       userDataRefetch();
     }
   }, [isDeletePostSuccess, userDataRefetch]);
+
+  if (!auth?.userId) {
+    navigate('/login', { replace: true });
+  }
 
   if (isUserLoading) {
     return <Spinner />;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -18,8 +18,12 @@ const MyPage = () => {
   const { name } = useCurrentPage();
   const { userData, isUserLoading, userDataRefetch } = useFetchUser(
     auth?.userId as string,
-  ); // TODO: refetch 할 때마다 데이터 로딩 처리하기
+  );
   const { deletePostMutate, isDeletePostSuccess } = useFetchDeletePost();
+
+  const isSameId = () => {
+    return userData?._id === auth?.userId;
+  };
 
   useEffect(() => {
     if (isDeletePostSuccess) {
@@ -30,43 +34,50 @@ const MyPage = () => {
   if (isUserLoading) {
     return <Spinner />;
   }
+
   return (
     <MyPageWrapper>
-      {userData && (
-        <MyInfo
-          id={userData._id}
-          image={userData.image}
-          name={userData.fullName}
-          likes={userData.posts.reduce(
-            (likes, post) => likes + post.likes.length,
-            0,
-          )}
-          followers={userData.followers?.length}
-          following={userData.following?.length}
-          myLevel={calculateLevel(userData)}
-          myColor={getUserLevelInfo(calculateLevel(userData)).userColor}
-          myEmoji={getUserLevelInfo(calculateLevel(userData)).userEmoji}
-        />
-      )}
-      <PostsListContainer>
-        <PostsListTitle>
-          {userData?.posts.length === 0
-            ? USER_POSTS_TITLE.NO_POSTS
-            : USER_POSTS_TITLE.POSTS}
-        </PostsListTitle>
-        <PostsListUl>
-          {userData?.posts?.map((post) => (
-            <PostListItem
-              key={post._id}
-              id={post._id}
-              title={post.title}
+      {isSameId() ? (
+        <>
+          {userData && (
+            <MyInfo
+              id={userData._id}
               image={userData.image}
-              canDeletePost={name === MY_PAGE}
-              deletePostMutate={deletePostMutate}
+              name={userData.fullName}
+              likes={userData.posts.reduce(
+                (likes, post) => likes + post.likes.length,
+                0,
+              )}
+              followers={userData.followers?.length}
+              following={userData.following?.length}
+              myLevel={calculateLevel(userData)}
+              myColor={getUserLevelInfo(calculateLevel(userData)).userColor}
+              myEmoji={getUserLevelInfo(calculateLevel(userData)).userEmoji}
             />
-          ))}
-        </PostsListUl>
-      </PostsListContainer>
+          )}
+          <PostsListContainer>
+            <PostsListTitle>
+              {userData?.posts.length === 0
+                ? USER_POSTS_TITLE.NO_POSTS
+                : USER_POSTS_TITLE.POSTS}
+            </PostsListTitle>
+            <PostsListUl>
+              {userData?.posts?.map((post) => (
+                <PostListItem
+                  key={post._id}
+                  id={post._id}
+                  title={post.title}
+                  image={userData.image}
+                  canDeletePost={name === MY_PAGE}
+                  deletePostMutate={deletePostMutate}
+                />
+              ))}
+            </PostsListUl>
+          </PostsListContainer>
+        </>
+      ) : (
+        <Spinner />
+      )}
     </MyPageWrapper>
   );
 };

--- a/src/pages/SignUpPage/components/InputEmail.tsx
+++ b/src/pages/SignUpPage/components/InputEmail.tsx
@@ -38,6 +38,7 @@ const InputEmail = ({
           )}
         </InputWrapper>
         <Button
+          disabled={invalidEmailMsg || validEmailMsg == '' ? true : false}
           type="button"
           onClick={handleClickDuplicatedEmailCheckBtn}
           style={{

--- a/src/pages/SignUpPage/components/InputEmail.tsx
+++ b/src/pages/SignUpPage/components/InputEmail.tsx
@@ -100,6 +100,13 @@ const Input = styled.input`
   ::placeholder {
     color: ${ANGOLA_STYLES.color.dark};
     font-size: ${ANGOLA_STYLES.textSize.text};
+
+    @media (max-width: 1024px) {
+      font-size: 12px;
+    }
+    @media (max-width: 700px) {
+      font-size: 10px;
+    }
   }
 
   &:focus {

--- a/src/pages/SignUpPage/components/InputEmail.tsx
+++ b/src/pages/SignUpPage/components/InputEmail.tsx
@@ -42,6 +42,7 @@ const InputEmail = ({
           onClick={handleClickDuplicatedEmailCheckBtn}
           style={{
             width: '100px',
+            height: '36px',
             padding: '8px 0px',
             fontSize: ANGOLA_STYLES.textSize.titleSm,
           }}>

--- a/src/pages/SignUpPage/components/InputFullName.tsx
+++ b/src/pages/SignUpPage/components/InputFullName.tsx
@@ -38,6 +38,7 @@ const InputFullName = ({
           )}
         </InputWrapper>
         <Button
+          disabled={invalidFullNameMsg || validFullNameMsg == '' ? true : false}
           type="button"
           onClick={handleClickDuplicatedFullNameCheckBtn}
           style={{

--- a/src/pages/SignUpPage/components/InputFullName.tsx
+++ b/src/pages/SignUpPage/components/InputFullName.tsx
@@ -42,6 +42,7 @@ const InputFullName = ({
           onClick={handleClickDuplicatedFullNameCheckBtn}
           style={{
             width: '100px',
+            height: '36px',
             padding: '8px 0',
             fontSize: ANGOLA_STYLES.textSize.titleSm,
           }}>

--- a/src/pages/SignUpPage/components/InputFullName.tsx
+++ b/src/pages/SignUpPage/components/InputFullName.tsx
@@ -100,6 +100,13 @@ const Input = styled.input`
   ::placeholder {
     color: ${ANGOLA_STYLES.color.dark};
     font-size: ${ANGOLA_STYLES.textSize.text};
+
+    @media (max-width: 1024px) {
+      font-size: 10px;
+    }
+    @media (max-width: 700px) {
+      font-size: 8px;
+    }
   }
 `;
 

--- a/src/pages/SignUpPage/components/InputPassword.tsx
+++ b/src/pages/SignUpPage/components/InputPassword.tsx
@@ -84,6 +84,13 @@ const Input = styled.input`
   ::placeholder {
     color: ${ANGOLA_STYLES.color.dark};
     font-size: ${ANGOLA_STYLES.textSize.text};
+
+    @media (max-width: 1024px) {
+      font-size: 10px;
+    }
+    @media (max-width: 700px) {
+      font-size: 8px;
+    }
   }
 
   &:focus {

--- a/src/pages/SignUpPage/components/InputPasswordConfirm.tsx
+++ b/src/pages/SignUpPage/components/InputPasswordConfirm.tsx
@@ -93,6 +93,13 @@ const Input = styled.input`
   ::placeholder {
     color: ${ANGOLA_STYLES.color.dark};
     font-size: ${ANGOLA_STYLES.textSize.text};
+
+    @media (max-width: 1024px) {
+      font-size: 10px;
+    }
+    @media (max-width: 700px) {
+      font-size: 8px;
+    }
   }
 
   &:focus {

--- a/src/pages/SignUpPage/components/Modals.tsx
+++ b/src/pages/SignUpPage/components/Modals.tsx
@@ -9,12 +9,9 @@ interface ModalsProps {
 
 export const SignUpSuccessModal = ({ onClick: handleClick }: ModalsProps) => {
   return (
-    <Modal
-      onClose={handleClick}
-      footerShow={false}>
+    <Modal onClose={handleClick}>
       <Content>
         <Msg>{MODAL.MSG.SIGN_UP.SUCCESS}</Msg>
-        <SubMsg>{MODAL.SUB_MSG}</SubMsg>
       </Content>
     </Modal>
   );
@@ -22,12 +19,9 @@ export const SignUpSuccessModal = ({ onClick: handleClick }: ModalsProps) => {
 
 export const SignUpFailModal = ({ onClick: handleClick }: ModalsProps) => {
   return (
-    <Modal
-      onClose={handleClick}
-      footerShow={false}>
+    <Modal onClose={handleClick}>
       <Content>
         <Msg>{MODAL.MSG.SIGN_UP.FAIL}</Msg>
-        <SubMsg>{MODAL.SUB_MSG}</SubMsg>
       </Content>
     </Modal>
   );
@@ -35,12 +29,9 @@ export const SignUpFailModal = ({ onClick: handleClick }: ModalsProps) => {
 
 export const CheckEmailModal = ({ onClick: handleClick }: ModalsProps) => {
   return (
-    <Modal
-      onClose={handleClick}
-      footerShow={false}>
+    <Modal onClose={handleClick}>
       <Content>
         <Msg>{MODAL.MSG.WARN.EMAIL}</Msg>
-        <SubMsg>{MODAL.SUB_MSG}</SubMsg>
       </Content>
     </Modal>
   );
@@ -48,12 +39,9 @@ export const CheckEmailModal = ({ onClick: handleClick }: ModalsProps) => {
 
 export const CheckPasswordModal = ({ onClick: handleClick }: ModalsProps) => {
   return (
-    <Modal
-      onClose={handleClick}
-      footerShow={false}>
+    <Modal onClose={handleClick}>
       <Content>
         <Msg>{MODAL.MSG.WARN.PASSWORD}</Msg>
-        <SubMsg>{MODAL.SUB_MSG}</SubMsg>
       </Content>
     </Modal>
   );
@@ -61,12 +49,9 @@ export const CheckPasswordModal = ({ onClick: handleClick }: ModalsProps) => {
 
 export const CheckFullNameModal = ({ onClick: handleClick }: ModalsProps) => {
   return (
-    <Modal
-      onClose={handleClick}
-      footerShow={false}>
+    <Modal onClose={handleClick}>
       <Content>
         <Msg>{MODAL.MSG.WARN.FULLNAME}</Msg>
-        <SubMsg>{MODAL.SUB_MSG}</SubMsg>
       </Content>
     </Modal>
   );
@@ -84,9 +69,4 @@ const Content = styled.div`
 
 const Msg = styled.div`
   font-size: ${ANGOLA_STYLES.textSize.titleLg};
-`;
-
-const SubMsg = styled.div`
-  font-size: ${ANGOLA_STYLES.textSize.text};
-  color: ${ANGOLA_STYLES.color.dark};
 `;

--- a/src/pages/SignUpPage/constants/index.ts
+++ b/src/pages/SignUpPage/constants/index.ts
@@ -64,5 +64,4 @@ export const MODAL = {
       FULLNAME: '닉네임 중복 검사를 해주세요!',
     },
   },
-  SUB_MSG: 'Enter/Esc 또는 주변을 클릭하세요.',
 };

--- a/src/pages/SignUpPage/hooks/useEmailCheck.ts
+++ b/src/pages/SignUpPage/hooks/useEmailCheck.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
-import { checkEmailPattern } from '@utils';
+import { checkDuplicatedEmail, checkEmailPattern } from '@utils';
 import { useFetchUsers } from '@apis/user';
 import { MSG, SIGNUP_INITIAL_VALUE } from '../constants';
 
@@ -16,6 +16,9 @@ const useEmailCheck = ({ setIsSubmitted }: useEmailCheckProps) => {
   const { usersData, isUsersError } = useFetchUsers();
 
   const handleChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {
+    const { isValidEmail, msg } = checkEmailPattern({
+      email: e.target.value,
+    });
     setEmail(e.target.value);
     setIsDuplicatedEmailChecked(false);
     setValidEmailMsg('');
@@ -23,23 +26,26 @@ const useEmailCheck = ({ setIsSubmitted }: useEmailCheckProps) => {
 
     if (!e.target.value) {
       setInvalidEmailMsg(MSG.WARNING.EMPTY.EMAIL);
+    } else if (!isValidEmail) {
+      setInvalidEmailMsg(msg);
     } else {
+      setValidEmailMsg(msg);
       setInvalidEmailMsg('');
     }
   };
 
   const handleClickDuplicatedEmailCheckBtn = () => {
-    const { isValidEmail, msg } = checkEmailPattern({ email, usersData });
+    const { isValidEmail, msg } = checkDuplicatedEmail({ email, usersData });
 
     if (isUsersError || !usersData) {
       console.error(MSG.ERROR.DUPLICATE_CHECK);
       return;
     }
     if (!isValidEmail) {
+      setValidEmailMsg('');
       setInvalidEmailMsg(msg);
     } else {
       setValidEmailMsg(msg);
-      setInvalidEmailMsg('');
       setIsDuplicatedEmailChecked(true);
     }
   };

--- a/src/pages/SignUpPage/hooks/useFullNameCheck.ts
+++ b/src/pages/SignUpPage/hooks/useFullNameCheck.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
-import { checkFullNamePattern } from '@utils';
+import { checkDuplicatedFullName, checkFullNamePattern } from '@utils';
 import { useFetchUsers } from '@apis/user';
 import { MSG, SIGNUP_INITIAL_VALUE } from '../constants';
 
@@ -18,6 +18,10 @@ const useFullNameCheck = ({ setIsSubmitted }: useFullNameCheckProps) => {
   const { usersData, isUsersError } = useFetchUsers();
 
   const handleChangeFullName = (e: ChangeEvent<HTMLInputElement>) => {
+    const { isValidFullName, msg } = checkFullNamePattern({
+      fullName: e.target.value,
+      usersData,
+    });
     setFullName(e.target.value);
     setIsDuplicatedFullNameChecked(false);
     setValidFullNameMsg('');
@@ -25,13 +29,18 @@ const useFullNameCheck = ({ setIsSubmitted }: useFullNameCheckProps) => {
 
     if (!e.target.value) {
       setInvalidFullNameMsg(MSG.WARNING.EMPTY.FULLNAME);
+    } else if (msg === '이미 가입된 닉네임입니다.') {
+      setValidFullNameMsg('닉네임 형식이 올바릅니다.');
+    } else if (!isValidFullName) {
+      setInvalidFullNameMsg(msg);
     } else {
       setInvalidFullNameMsg('');
+      setValidFullNameMsg('닉네임 형식이 올바릅니다.');
     }
   };
 
   const handleClickDuplicatedFullNameCheckBtn = () => {
-    const { isValidFullName, msg } = checkFullNamePattern({
+    const { isValidFullName, msg } = checkDuplicatedFullName({
       fullName,
       usersData,
     });
@@ -41,10 +50,10 @@ const useFullNameCheck = ({ setIsSubmitted }: useFullNameCheckProps) => {
       return;
     }
     if (!isValidFullName) {
+      setValidFullNameMsg('');
       setInvalidFullNameMsg(msg);
     } else {
       setValidFullNameMsg(msg);
-      setInvalidFullNameMsg('');
       setIsDuplicatedFullNameChecked(true);
     }
   };

--- a/src/pages/SignUpPage/hooks/useSubmit.ts
+++ b/src/pages/SignUpPage/hooks/useSubmit.ts
@@ -30,8 +30,11 @@ const useSubmit = ({
   useEffect(() => {
     email.length > 5 &&
     password.length > 4 &&
+    password.length < 16 &&
     passwordConfirm.length > 4 &&
-    fullName.length > 2
+    passwordConfirm.length < 16 &&
+    fullName.length > 2 &&
+    fullName.length < 9
       ? setIsSignUpDisabled(false)
       : setIsSignUpDisabled(true);
   }, [email, password, passwordConfirm, fullName]);

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
+import { Navigate } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
 import Button from '@components/Button';
+import { authInfoState } from '@store/auth';
 import { ANGOLA_STYLES } from '@styles/commonStyles';
 import {
   InputEmail,
@@ -27,6 +30,7 @@ import {
 } from './hooks';
 
 const SignUpPage = () => {
+  const myId = useRecoilValue(authInfoState)?.userId;
   const navigate = useNavigate();
   const [isSubmitted, setIsSubmitted] = useState(false);
 
@@ -85,85 +89,84 @@ const SignUpPage = () => {
     });
 
   return (
-    <>
-      <SignUpContainer>
-        <Form onSubmit={handleSubmit}>
-          <Wrapper>
-            <Label>{INPUT.LABEL.EMAIL}</Label>
-            <InputEmail
-              handleChangeEmail={handleChangeEmail}
-              handleClickDuplicatedEmailCheckBtn={
-                handleClickDuplicatedEmailCheckBtn
-              }
-              isDuplicatedEmailChecked={isDuplicatedEmailChecked}
-              invalidEmailMsg={invalidEmailMsg}
-              validEmailMsg={validEmailMsg}
-            />
-          </Wrapper>
-          <Wrapper>
-            <Label>{INPUT.LABEL.PASSWORD}</Label>
-            <InputPassword
-              isPasswordShown={isPasswordShown}
-              handleChangePassword={handleChangePassword}
-              handleClickPasswordShown={handleClickPasswordShown}
-              invalidPasswordMsg={invalidPasswordMsg}
-            />
-            <InputPasswordConfirm
-              isPasswordConfirmShown={isPasswordConfirmShown}
-              handleChangePasswordConfirm={handleChangePasswordConfirm}
-              handleClickPasswordConfirmShown={handleClickPasswordConfirmShown}
-              invalidPasswordConfirmMsg={invalidPasswordConfirmMsg}
-              validPasswordConfirmMsg={validPasswordConfirmMsg}
-            />
-          </Wrapper>
-          <Wrapper>
-            <Label>{INPUT.LABEL.FULLNAME}</Label>
-            <InputFullName
-              handleChangeFullName={handleChangeFullName}
-              isDuplicatedFullNameChecked={isDuplicatedFullNameChecked}
-              handleClickDuplicatedFullNameCheckBtn={
-                handleClickDuplicatedFullNameCheckBtn
-              }
-              invalidFullNameMsg={invalidFullNameMsg}
-              validFullNameMsg={validFullNameMsg}
-            />
-          </Wrapper>
-          <Button
-            type="submit"
-            size="md"
-            style={{
-              width: '150px',
-              fontSize: ANGOLA_STYLES.textSize.title,
-            }}
-            disabled={isSignUpDisabled}>
-            {BUTTON.SIGN_UP}
-          </Button>
-        </Form>
-        {isSignUpSuccess && (
-          <SignUpSuccessModal onClick={() => navigate('/login')} />
-        )}
-        {isSignUpError && (
-          <SignUpFailModal onClick={() => window.location.reload()} />
-        )}
-        {isSubmitted && (
-          <>
-            {!isDuplicatedEmailChecked ? (
-              <CheckEmailModal onClick={() => setIsSubmitted(false)} />
-            ) : (
-              <>
-                {(invalidPasswordMsg || invalidPasswordConfirmMsg) && (
-                  <CheckPasswordModal onClick={() => setIsSubmitted(false)} />
+    <SignUpContainer>
+      <Form onSubmit={handleSubmit}>
+        <Wrapper>
+          <Label>{INPUT.LABEL.EMAIL}</Label>
+          <InputEmail
+            handleChangeEmail={handleChangeEmail}
+            handleClickDuplicatedEmailCheckBtn={
+              handleClickDuplicatedEmailCheckBtn
+            }
+            isDuplicatedEmailChecked={isDuplicatedEmailChecked}
+            invalidEmailMsg={invalidEmailMsg}
+            validEmailMsg={validEmailMsg}
+          />
+        </Wrapper>
+        <Wrapper>
+          <Label>{INPUT.LABEL.PASSWORD}</Label>
+          <InputPassword
+            isPasswordShown={isPasswordShown}
+            handleChangePassword={handleChangePassword}
+            handleClickPasswordShown={handleClickPasswordShown}
+            invalidPasswordMsg={invalidPasswordMsg}
+          />
+          <InputPasswordConfirm
+            isPasswordConfirmShown={isPasswordConfirmShown}
+            handleChangePasswordConfirm={handleChangePasswordConfirm}
+            handleClickPasswordConfirmShown={handleClickPasswordConfirmShown}
+            invalidPasswordConfirmMsg={invalidPasswordConfirmMsg}
+            validPasswordConfirmMsg={validPasswordConfirmMsg}
+          />
+        </Wrapper>
+        <Wrapper>
+          <Label>{INPUT.LABEL.FULLNAME}</Label>
+          <InputFullName
+            handleChangeFullName={handleChangeFullName}
+            isDuplicatedFullNameChecked={isDuplicatedFullNameChecked}
+            handleClickDuplicatedFullNameCheckBtn={
+              handleClickDuplicatedFullNameCheckBtn
+            }
+            invalidFullNameMsg={invalidFullNameMsg}
+            validFullNameMsg={validFullNameMsg}
+          />
+        </Wrapper>
+        <Button
+          type="submit"
+          size="md"
+          style={{
+            width: '150px',
+            fontSize: ANGOLA_STYLES.textSize.title,
+          }}
+          disabled={isSignUpDisabled}>
+          {BUTTON.SIGN_UP}
+        </Button>
+      </Form>
+      {isSignUpSuccess && (
+        <SignUpSuccessModal onClick={() => navigate('/login')} />
+      )}
+      {isSignUpError && (
+        <SignUpFailModal onClick={() => window.location.reload()} />
+      )}
+      {isSubmitted && (
+        <>
+          {!isDuplicatedEmailChecked ? (
+            <CheckEmailModal onClick={() => setIsSubmitted(false)} />
+          ) : (
+            <>
+              {(invalidPasswordMsg || invalidPasswordConfirmMsg) && (
+                <CheckPasswordModal onClick={() => setIsSubmitted(false)} />
+              )}
+              {!(invalidPasswordMsg || invalidPasswordConfirmMsg) &&
+                !isDuplicatedFullNameChecked && (
+                  <CheckFullNameModal onClick={() => setIsSubmitted(false)} />
                 )}
-                {!(invalidPasswordMsg || invalidPasswordConfirmMsg) &&
-                  !isDuplicatedFullNameChecked && (
-                    <CheckFullNameModal onClick={() => setIsSubmitted(false)} />
-                  )}
-              </>
-            )}
-          </>
-        )}
-      </SignUpContainer>
-    </>
+            </>
+          )}
+        </>
+      )}
+      {myId && !isSignUpSuccess && <Navigate to="/" />}
+    </SignUpContainer>
   );
 };
 

--- a/src/pages/UserPage/UserInfo.tsx
+++ b/src/pages/UserPage/UserInfo.tsx
@@ -91,7 +91,13 @@ const UserInfo = ({
             toggle={isFollowed}
             size="md"
             onClick={handleClickFollowButton}
-            disabled={disabledFollowButton()}>
+            disabled={disabledFollowButton()}
+            style={{
+              width: '120px',
+              height: '40px',
+              padding: '0',
+              fontSize: `${ANGOLA_STYLES.textSize.text}`,
+            }}>
             {isFollowed
               ? `${FOLLOW_MESSAGE.UN_FOLLOW}`
               : `${FOLLOW_MESSAGE.FOLLOW}`}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,8 @@ export { pxToRem } from '@utils/pxToRem';
 export { calculateLevel, getUserLevelInfo } from '@utils/calculateUserLevel';
 export {
   checkEmailPattern,
+  checkDuplicatedEmail,
   checkFullNamePattern,
+  checkDuplicatedFullName,
   checkPassWordPattern,
 } from '@utils/userAuthentication';

--- a/src/utils/userAuthentication.ts
+++ b/src/utils/userAuthentication.ts
@@ -1,13 +1,10 @@
 import { User } from '@type';
 
-const NUMBER = /[0-9]/;
-const CHARACTER = /[a-zA-Z]/;
-const SPECIAL_CHARACTER = /[~!@#$%^&*()_+|<>?:{}]/;
+const PASSWORD_REGEXP = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{5,15}$/;
 const EMAIL_REGEXP = /[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/;
-const FULLNAME_MIN_LENGTH = 3;
-const FULLNAME_MAX_LENGTH = 8;
-const PASSWORD_MIN_LENGTH = 5;
-const PASSWORD_MAX_LENGTH = 15;
+const SPECIAL_CHARACTER_REGEXP = /[~!@#$%^&*()_+|<>?:{}]/;
+const FULL_NAME_MIN_LENGTH = 3;
+const FULL_NAME_MAX_LENGTH = 8;
 
 interface checkEmailPatternProps {
   email: string;
@@ -57,9 +54,9 @@ export const checkFullNamePattern = ({
   let msg;
 
   if (
-    SPECIAL_CHARACTER.test(trimmedFullName) ||
-    trimmedFullName.length > FULLNAME_MAX_LENGTH ||
-    trimmedFullName.length < FULLNAME_MIN_LENGTH
+    SPECIAL_CHARACTER_REGEXP.test(trimmedFullName) ||
+    trimmedFullName.length < FULL_NAME_MIN_LENGTH ||
+    trimmedFullName.length > FULL_NAME_MAX_LENGTH
   ) {
     msg = '닉네임은 3자리 이상 8자리 이하 문자 또는 숫자로 구성하여야 합니다.';
     isValidFullName = false;
@@ -81,20 +78,16 @@ export const checkPassWordPattern = ({
   confirmNewPassWord,
 }: checkPassWordPatternProps) => {
   const trimmedPassWord = newPassWord.trim();
+
   let isValidPassword = false;
   let isValidPasswordConfirm = false;
   let passwordMsg = '';
   let passwordConfirmMsg = '';
+  console.log(trimmedPassWord.length);
 
-  if (
-    !NUMBER.test(trimmedPassWord) ||
-    !CHARACTER.test(trimmedPassWord) ||
-    !SPECIAL_CHARACTER.test(trimmedPassWord) ||
-    trimmedPassWord.length <= PASSWORD_MIN_LENGTH ||
-    trimmedPassWord.length >= PASSWORD_MAX_LENGTH
-  ) {
+  if (!PASSWORD_REGEXP.test(trimmedPassWord)) {
     passwordMsg =
-      '비밀번호는 5자리 이상 15자 이하 문자, 숫자, 특수문자로 구성하여야 합니다.';
+      '비밀번호는 5자리 이상 15자 이하 문자, 숫자, 특수문자를 모두 포함해야 합니다.';
     isValidPassword = false;
   } else {
     isValidPassword = true;

--- a/src/utils/userAuthentication.ts
+++ b/src/utils/userAuthentication.ts
@@ -121,7 +121,6 @@ export const checkPassWordPattern = ({
   let isValidPasswordConfirm = false;
   let passwordMsg = '';
   let passwordConfirmMsg = '';
-  console.log(trimmedPassWord.length);
 
   if (!PASSWORD_REGEXP.test(trimmedPassWord)) {
     passwordMsg =

--- a/src/utils/userAuthentication.ts
+++ b/src/utils/userAuthentication.ts
@@ -103,6 +103,9 @@ export const checkPassWordPattern = ({
   if (newPassWord !== confirmNewPassWord) {
     passwordConfirmMsg = '비밀번호가 일치하지 않습니다.';
     isValidPasswordConfirm = false;
+  } else if (newPassWord === '' && confirmNewPassWord === '') {
+    passwordConfirmMsg = '비밀번호를 입력해주세요';
+    isValidPasswordConfirm = false;
   } else {
     passwordConfirmMsg = '비밀번호가 일치합니다.';
     isValidPasswordConfirm = true;

--- a/src/utils/userAuthentication.ts
+++ b/src/utils/userAuthentication.ts
@@ -8,10 +8,20 @@ const FULL_NAME_MAX_LENGTH = 8;
 
 interface checkEmailPatternProps {
   email: string;
+}
+
+interface checkDuplicatedEmailProps {
+  email: string;
   usersData?: User[];
 }
 
 interface checkFullNamePatternProps {
+  fullName: string;
+  usersData?: User[];
+  myFullName?: string;
+}
+
+interface checkDuplicatedFullNameProps {
   fullName: string;
   usersData?: User[];
   myFullName?: string;
@@ -22,10 +32,7 @@ interface checkPassWordPatternProps {
   confirmNewPassWord?: string;
 }
 
-export const checkEmailPattern = ({
-  email,
-  usersData,
-}: checkEmailPatternProps) => {
+export const checkEmailPattern = ({ email }: checkEmailPatternProps) => {
   const trimmedEmail = email.trim();
   let isValidEmail;
   let msg;
@@ -33,7 +40,21 @@ export const checkEmailPattern = ({
   if (!EMAIL_REGEXP.test(trimmedEmail)) {
     msg = '유효한 이메일 주소가 아닙니다.';
     isValidEmail = false;
-  } else if (usersData?.find((user) => user.email === email)) {
+  } else {
+    msg = '유효한 이메일 주소입니다.';
+    isValidEmail = true;
+  }
+  return { msg, isValidEmail };
+};
+
+export const checkDuplicatedEmail = ({
+  email,
+  usersData,
+}: checkDuplicatedEmailProps) => {
+  let isValidEmail;
+  let msg;
+
+  if (usersData?.find((user) => user.email === email)) {
     msg = '이미 가입된 이메일입니다.';
     isValidEmail = false;
   } else {
@@ -64,6 +85,23 @@ export const checkFullNamePattern = ({
     myFullName !== fullName &&
     usersData?.find((user) => user.fullName === fullName)
   ) {
+    msg = '이미 가입된 닉네임입니다.';
+    isValidFullName = false;
+  } else {
+    msg = '사용할 수 있는 닉네임입니다.';
+    isValidFullName = true;
+  }
+  return { msg, isValidFullName };
+};
+
+export const checkDuplicatedFullName = ({
+  fullName,
+  usersData,
+}: checkDuplicatedFullNameProps) => {
+  let isValidFullName;
+  let msg;
+
+  if (usersData?.find((user) => user.fullName === fullName)) {
     msg = '이미 가입된 닉네임입니다.';
     isValidFullName = false;
   } else {


### PR DESCRIPTION
## 📑 구현 사항 

- [x] 닉네임 9글자 이상일 때와 비밀번호 15글자 이상일때, 가입완료 버튼 disabled 처리
- [x] 유효성 검사 결과와 중복 검사 결과 구분하기.
- [x] 화면이 작아질 때 placeholder 폰트 사이즈 줄이기
- [x] 회원가입 모달들에 부수적인 문구를 지우고, 확인 버튼 추가하기
- [x] 로그인된 상태에서 /signup 으로 url 접속하면, 회원가입 페이지 접속 막기.

<br/>

## 🚧 특이 사항

- 유효성 검사 결과와 중복 검사 결과 구분하기 위해, 유효성을 검사하는 userAuthentication 파일에서 checkEmailPattern, checkFullNamePattern 함수를 분리해야했습니다. 
checkEmailPattern은 checkDuplicatedEmail 함수로 분리하였지만, checkFullNamePattern은 마이페이지에서 사용하고 있는 함수라 변경해버리면 지윤님께서 다시 수정하셔야하는 수고가 생깁니다.
시간이 많이 남아있지 않기에 우선, checkFullNamePattern이 이미 역할을 가지고 있는 checkDuplicatedFullName 함수를 구현하였습니다. (checkFullNamePattern은 수정하지 않고, 그대로 두었습니다!) 
만약 지윤님께서도 유효성과 중복 검사를 분리하여 사용하실거면 다시 수정하도록 하겠습니다!

```typescript
export const checkFullNamePattern = ({
  fullName,
  usersData,
  myFullName,
}: checkFullNamePatternProps) => {
  const trimmedFullName = fullName.trim();

  let isValidFullName;
  let msg;

  if (
    SPECIAL_CHARACTER_REGEXP.test(trimmedFullName) ||
    trimmedFullName.length < FULL_NAME_MIN_LENGTH ||
    trimmedFullName.length > FULL_NAME_MAX_LENGTH
  ) {
    msg = '닉네임은 3자리 이상 8자리 이하 문자 또는 숫자로 구성하여야 합니다.';
    isValidFullName = false;
  } else if (
    myFullName !== fullName &&
    usersData?.find((user) => user.fullName === fullName)
  ) {
    msg = '이미 가입된 닉네임입니다.';
    isValidFullName = false;
  } else {
    msg = '사용할 수 있는 닉네임입니다.';
    isValidFullName = true;
  }
  return { msg, isValidFullName };
};

export const checkDuplicatedFullName = ({
  fullName,
  usersData,
}: checkDuplicatedFullNameProps) => {
  let isValidFullName;
  let msg;

  if (usersData?.find((user) => user.fullName === fullName)) {
    msg = '이미 가입된 닉네임입니다.';
    isValidFullName = false;
  } else {
    msg = '사용할 수 있는 닉네임입니다.';
    isValidFullName = true;
  }
  return { msg, isValidFullName };
};
```

</br>

## 🚨관련 이슈

#182