### PR TITLE
[Fix] - PostPage 뒤로가기 처리 및 최적화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,9 +1279,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.6",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.6.tgz",
-      "integrity": "sha512-RK/kBbYOQQHLYj9Z95eh7S6t7gq4Ojt/NT8HTk8bWVhA5DaF+5SMnxHKkP4gPNN3wAZkKP+VjAf0ebtYzf+fxg==",
+      "version": "15.7.7",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
+      "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog==",
       "dev": true
     },
     "node_modules/@types/react": {
@@ -3313,9 +3313,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
-      "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.3.tgz",
+      "integrity": "sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4546,9 +4546,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prop-types": {
-      "version": "15.7.6",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.6.tgz",
-      "integrity": "sha512-RK/kBbYOQQHLYj9Z95eh7S6t7gq4Ojt/NT8HTk8bWVhA5DaF+5SMnxHKkP4gPNN3wAZkKP+VjAf0ebtYzf+fxg==",
+      "version": "15.7.7",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
+      "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog==",
       "dev": true
     },
     "@types/react": {
@@ -5979,9 +5979,9 @@
       }
     },
     "rollup": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
-      "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.3.tgz",
+      "integrity": "sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/src/pages/PostPage/Hooks/useCheckVoted.ts
+++ b/src/pages/PostPage/Hooks/useCheckVoted.ts
@@ -21,7 +21,7 @@ const useCheckVoted = ({
 }: useCheckVotedProps) => {
   useEffect(() => {
     setSubmitValue(voted);
-  }, [voted, setSubmitValue]);
+  }, [voted]);
 
   useEffect(() => {
     if (postData) {
@@ -37,7 +37,7 @@ const useCheckVoted = ({
         setSubmitValue(userVote);
       }
     }
-  }, [myId, postData, submitValue, setSubmitValue, setVotedValue]);
+  }, [myId, postData, submitValue]);
 };
 
 export default useCheckVoted;

--- a/src/pages/PostPage/Hooks/useCommentNotification.ts
+++ b/src/pages/PostPage/Hooks/useCommentNotification.ts
@@ -36,7 +36,7 @@ const useCommentNotification = ({
         postId: postData._id,
       });
     }
-  }, [isVoted, postData, myId, createNotificationMutate, setIsVoted]);
+  }, [isVoted, postData, myId]);
 };
 
 export default useCommentNotification;

--- a/src/pages/PostPage/Hooks/useControlRouteByComment.ts
+++ b/src/pages/PostPage/Hooks/useControlRouteByComment.ts
@@ -30,7 +30,7 @@ const useControlRouteByComment = ({
         : searchParams.delete(SEARCH_KEYS.VOTED);
       setSearchParams(searchParams, { replace: true });
     }
-  }, [searchParams, setSearchParams, submitValue, show]);
+  }, [submitValue, show]);
 };
 
 export default useControlRouteByComment;

--- a/src/pages/PostPage/Hooks/useControlRouteByComment.ts
+++ b/src/pages/PostPage/Hooks/useControlRouteByComment.ts
@@ -28,7 +28,7 @@ const useControlRouteByComment = ({
       submitValue
         ? searchParams.set(SEARCH_KEYS.VOTED, submitValue)
         : searchParams.delete(SEARCH_KEYS.VOTED);
-      setSearchParams(searchParams);
+      setSearchParams(searchParams, { replace: true });
     }
   }, [searchParams, setSearchParams, submitValue, show]);
 };

--- a/src/pages/PostPage/Hooks/useCreateComment.ts
+++ b/src/pages/PostPage/Hooks/useCreateComment.ts
@@ -41,7 +41,7 @@ const useCreateComment = ({
       });
     }
     searchParams.set(SEARCH_KEYS.VOTED, votedValue);
-    setSearchParams(searchParams);
+    setSearchParams(searchParams, { replace: true });
     setComment('');
     setSubmitValue('');
     setIsVoted(true);

--- a/src/pages/PostPage/Hooks/useDeleteComment.ts
+++ b/src/pages/PostPage/Hooks/useDeleteComment.ts
@@ -27,7 +27,7 @@ const useDeleteComment = ({
 
   useEffect(() => {
     setCommentsData(comments);
-  }, [comments.length, comments, setCommentsData]);
+  }, [comments.length, comments]);
 
   return {
     commentsData,

--- a/src/pages/PostPage/Hooks/useGetDeleteCommentState.ts
+++ b/src/pages/PostPage/Hooks/useGetDeleteCommentState.ts
@@ -21,7 +21,7 @@ const useGetDeleteCommentState = ({
   const deleteComment = (id: string) => {
     deleteCommentMutate({ id });
     searchParams.delete(SEARCH_KEYS.VOTED);
-    setSearchParams(searchParams);
+    setSearchParams(searchParams, { replace: true });
     setSubmitValue('');
   };
 

--- a/src/pages/PostPage/index.tsx
+++ b/src/pages/PostPage/index.tsx
@@ -31,6 +31,11 @@ interface PostPageProps {
 
 const PostPage = ({ voted, show, postId = '' }: PostPageProps) => {
   const myId = useRecoilValue(authInfoState)?.userId;
+
+  if (!myId && window.location.pathname.includes('&')) {
+    postId = postId.slice(0, postId.indexOf('&'));
+  }
+
   const [votedValue, setVotedValue] = useState<string>('');
   const [submitValue, setSubmitValue] = useState<string | undefined>('');
   const [isVoted, setIsVoted] = useState(false);

--- a/src/pages/PostPage/index.tsx
+++ b/src/pages/PostPage/index.tsx
@@ -133,9 +133,11 @@ const PostPage = ({ voted, show, postId = '' }: PostPageProps) => {
                   )}
                 </>
               ) : (
-                <CommentHeader authorLevel={calculateLevel(postData.author)}>
-                  {COMMENT_HEADER}
-                </CommentHeader>
+                postData.comments.length > 0 && (
+                  <CommentHeader authorLevel={calculateLevel(postData.author)}>
+                    {COMMENT_HEADER}
+                  </CommentHeader>
+                )
               )}
               {postData && !isDeleteCommentError && (
                 <CommentList

--- a/src/pages/PostPage/index.tsx
+++ b/src/pages/PostPage/index.tsx
@@ -38,7 +38,7 @@ const PostPage = ({ voted, show, postId = '' }: PostPageProps) => {
 
   useEffect(() => {
     postRefetch();
-  }, [postId, postRefetch]);
+  }, [postId]);
 
   const isSamePostId = () => {
     return postId === postData?._id;

--- a/src/pages/PostPage/index.tsx
+++ b/src/pages/PostPage/index.tsx
@@ -31,11 +31,6 @@ interface PostPageProps {
 
 const PostPage = ({ voted, show, postId = '' }: PostPageProps) => {
   const myId = useRecoilValue(authInfoState)?.userId;
-
-  if (!myId && window.location.pathname.includes('&')) {
-    postId = postId.slice(0, postId.indexOf('&'));
-  }
-
   const [votedValue, setVotedValue] = useState<string>('');
   const [submitValue, setSubmitValue] = useState<string | undefined>('');
   const [isVoted, setIsVoted] = useState(false);


### PR DESCRIPTION
## 📑 구현 사항 

- [x] postpage에서 뒤로가기 처리해주기
- [x] postpage 댓글이 없을 때, 댓글 헤더 숨기기
- [x] useEffect 필요없는 의존성 줄이기
<br/>

## 🚧 특이 사항

- 댓글 창 (show=true)에서 뒤로 가기 -> post/:postId 로 이동.
- 투표율 (show=true&voted=A)에서 뒤로 가기 -> post/:postId 로 이동.
- 댓글 삭제 -> 댓글 창(show=true) -> post/:postId 로 이동.

</br>

## 🚨관련 이슈

#196 