### PR TITLE
[Style] - 검색 키워드 말줄임을 CSS로 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -158,7 +158,6 @@ const Title = styled.div`
 
 const Keyword = styled.div`
   color: ${ANGOLA_STYLES.color.white};
-  display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,7 +5,6 @@ import { ANGOLA_STYLES } from '@styles/commonStyles';
 import { TabBarList } from './components';
 import { SELECT_OPTION } from './constants';
 import { useSelect } from './hooks';
-import { getTruncatedKeyword } from './utils';
 
 interface HeaderProps {
   title: string;
@@ -63,8 +62,8 @@ const Header = ({ title, sortProps, keyword }: HeaderProps) => {
       )}
 
       <Title className={keyword ? 'search-result' : ''}>
-        {keyword ? getTruncatedKeyword({ keyword }) || '' : null}
-        {title}
+        <Keyword>{keyword}</Keyword>
+        <SubText>{title}</SubText>
       </Title>
 
       {keyword ? (
@@ -142,6 +141,7 @@ const SortIcon = styled.div`
 const Title = styled.div`
   color: ${ANGOLA_STYLES.color.white};
   font-size: ${ANGOLA_STYLES.textSize.title};
+  display: flex;
 
   @media (max-width: 1000px) {
     font-size: ${ANGOLA_STYLES.textSize.titleSm};
@@ -154,6 +154,19 @@ const Title = styled.div`
   @media (max-width: 450px) {
     font-size: ${ANGOLA_STYLES.textSize.text};
   }
+`;
+
+const Keyword = styled.div`
+  color: ${ANGOLA_STYLES.color.white};
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+`;
+
+const SubText = styled.div`
+  color: ${ANGOLA_STYLES.color.white};
 `;
 
 const TabBar = styled.ul`

--- a/src/components/Header/utils/index.ts
+++ b/src/components/Header/utils/index.ts
@@ -6,10 +6,6 @@ interface HandleClickTabBarProps {
   navigate: NavigateFunction;
 }
 
-interface getTruncatedKeyword {
-  keyword?: string;
-}
-
 export const handleClickTabBar = ({
   value,
   TARGET_VALUE,
@@ -28,8 +24,4 @@ export const handleClickTabBar = ({
     }
     navigate('/search/post?sort=recent');
   }
-};
-
-export const getTruncatedKeyword = ({ keyword }: getTruncatedKeyword) => {
-  return keyword!.length > 6 ? keyword!.slice(0, 6) + '...' : keyword;
 };


### PR DESCRIPTION
## 📑 구현 사항 

- [x] JS로 구현되어 있던 말줄임 코드를 CSS로 변경하였습니다.
```css
const Keyword = styled.div`
  color: ${ANGOLA_STYLES.color.white};
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
  max-width: 140px;
`;
```

<br/>

## 🚧 특이 사항
기존 JS 말줄임 구현 코드인 getTruncatedKeyword 함수를 삭제하였습니다.
```js
export const getTruncatedKeyword = ({ keyword }: getTruncatedKeyword) => {
  return keyword!.length > 6 ? keyword!.slice(0, 6) + '...' : keyword;
};
```


</br>

## 🚨관련 이슈

#222